### PR TITLE
Fix dependency issue at requirements_gpu.txt

### DIFF
--- a/requirements_gpu.txt
+++ b/requirements_gpu.txt
@@ -12,7 +12,7 @@ kiwisolver==1.3.2
 lmdb==1.2.1
 matplotlib==3.5.1
 networkx==2.6.3
-numpy==1.20.0
+numpy>=1.20.0
 opencv-python==4.5.4.60
 Pillow==8.4.0
 protobuf==3.19.1


### PR DESCRIPTION
The conflict is caused by:
    The user requested numpy==1.20.0
    imageio 2.13.3 depends on numpy
    imgaug 0.4.0 depends on numpy>=1.15
    matplotlib 3.5.1 depends on numpy>=1.17
    opencv-python 4.5.4.60 depends on numpy>=1.21.2

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts