### PR TITLE
Update reformat.py, fix the memory leaking if running backend as server mode

### DIFF
--- a/backend/tools/reformat.py
+++ b/backend/tools/reformat.py
@@ -10,7 +10,7 @@ import os
 import sys
 
 import pysrt
-import wordsegment
+import wordsegment as ws
 import re
 
 
@@ -19,6 +19,7 @@ def execute(path, lang='en'):
     if sys.getrecursionlimit() < 100000:
         sys.setrecursionlimit(100000)
 
+    wordsegment = ws.Segmenter()
     wordsegment.load()
     subs = pysrt.open(path)
     verb_forms = ["I'm", "you're", "he's", "she's", "we're", "it's", "isn't", "aren't", "they're", "there's", "wasn't",


### PR DESCRIPTION
if running the backend many many times as a part of server,  the global var( _segmenter) in wordsegment module leads to memory leaking. So create a new local wordsegment var to avoid this issue.