### PR TITLE
添加配置项支持忽略竖排文字

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -30,7 +30,8 @@ if not os.path.exists(os.path.join(os.path.dirname(os.path.dirname(__file__)), '
         f.write('[DEFAULT]\n')
         f.write('Interface = 简体中文\n')
         f.write('Language = ch\n')
-        f.write('Mode = fast')
+        f.write('Mode = fast\n')
+        f.write('IgnoreVertical = false')
 settings_config.read(MODE_CONFIG_PATH, encoding='utf-8')
 
 # 读取interface下的语言配置,e.g. ch.ini
@@ -247,6 +248,11 @@ DELETE_EMPTY_TIMESTAMP = True
 
 # 是否重新分词, 用于解决没有语句没有空格
 WORD_SEGMENTATION = True
+
+# 是否忽略竖排字幕
+IGNORE_VERTICAL_LINE = False
+if settings_config['DEFAULT']['IgnoreVertical'] == 'true':
+    IGNORE_VERTICAL_LINE = True
 
 # --------------------- 请根据自己的实际情况改 end-----------------------------
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -253,6 +253,7 @@ WORD_SEGMENTATION = True
 IGNORE_VERTICAL_LINE = False
 if settings_config['DEFAULT']['IgnoreVertical'] == 'true':
     IGNORE_VERTICAL_LINE = True
+    IGNORE_VERTICAL_TEXT_LEN_THRESHOLD = 2
 
 # --------------------- 请根据自己的实际情况改 end-----------------------------
 

--- a/backend/tools/subtitle_ocr.py
+++ b/backend/tools/subtitle_ocr.py
@@ -15,6 +15,12 @@ import shutil
 import numpy as np
 from collections import namedtuple
 
+def is_vertical_line(coordinate):
+    x_len = coordinate[1] - coordinate[0]
+    y_len = coordinate[3] - coordinate[2]
+    if x_len > 0 and y_len > 0 and x_len < y_len:
+        return True
+    return False
 
 def extract_subtitles(data, text_recogniser, img, raw_subtitle_file,
                       sub_area, options, dt_box_arg, rec_res_arg, ocr_loss_debug_path):
@@ -41,6 +47,8 @@ def extract_subtitles(data, text_recogniser, img, raw_subtitle_file,
     for content, coordinate in zip(text_res, coordinates):
         text = content[0]
         prob = content[1]
+        if is_vertical_line(coordinate) and config.IGNORE_VERTICAL_LINE:
+            continue      
         if sub_area is not None:
             selected = False
             # 初始化超界偏差为0

--- a/backend/tools/subtitle_ocr.py
+++ b/backend/tools/subtitle_ocr.py
@@ -15,11 +15,14 @@ import shutil
 import numpy as np
 from collections import namedtuple
 
-def is_vertical_line(coordinate):
+def is_vertical_line(coordinate, text):
     x_len = coordinate[1] - coordinate[0]
     y_len = coordinate[3] - coordinate[2]
-    if x_len > 0 and y_len > 0 and x_len < y_len:
-        return True
+    
+    if (x_len > 0 and y_len > 0) and x_len < y_len:
+        # 只有这行文字长度超过阀值，才判定为竖排文字，避免单个字符被误判
+        if text != None and len(text) >= config.IGNORE_VERTICAL_TEXT_LEN_THRESHOLD:
+            return True
     return False
 
 def extract_subtitles(data, text_recogniser, img, raw_subtitle_file,
@@ -47,7 +50,7 @@ def extract_subtitles(data, text_recogniser, img, raw_subtitle_file,
     for content, coordinate in zip(text_res, coordinates):
         text = content[0]
         prob = content[1]
-        if is_vertical_line(coordinate) and config.IGNORE_VERTICAL_LINE:
+        if config.IGNORE_VERTICAL_LINE and is_vertical_line(coordinate,text):
             continue      
         if sub_area is not None:
             selected = False


### PR DESCRIPTION
1. 添加IGNORE_VERTICAL_LINE来开关该功能， 默认为false
2. 添加IGNORE_VERTICAL_TEXT_LEN_THRESHOLD, 设置判断竖排文字长度的阀值，默认最短2个字符
