### PR TITLE
修复在gui界面选中多个分辨率不同的视频的时候有可能出现负数的问题

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -303,7 +303,6 @@ class SubtitleExtractorGUI:
                 if self.xmax > self.frame_width:
                     self.xmax = self.frame_width
                 print(f"{self.interface_config['SubtitleExtractorGUI']['SubtitleArea']}：({self.ymin},{self.ymax},{self.xmin},{self.xmax})")
-                subtitle_area = (self.ymin, self.ymax, self.xmin, self.xmax)
                 y_p = self.ymin / self.frame_height
                 h_p = (self.ymax - self.ymin) / self.frame_height
                 x_p = self.xmin / self.frame_width
@@ -313,6 +312,18 @@ class SubtitleExtractorGUI:
                 def task():
                     while self.video_paths:
                         video_path = self.video_paths.pop()
+                        # 获取当前视频的帧尺寸
+                        video_cap = cv2.VideoCapture(video_path)
+                        frame_width = int(video_cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+                        frame_height = int(video_cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+                        video_cap.release()
+                        # 根据当前视频的尺寸重新计算字幕区域
+                        subtitle_area = (
+                            int(y_p * frame_height),
+                            int((y_p + h_p) * frame_height),
+                            int(x_p * frame_width),
+                            int((x_p + w_p) * frame_width)
+                        )
                         self.se = backend.main.SubtitleExtractor(video_path, subtitle_area)
                         self.se.run()
                 Thread(target=task, daemon=True).start()


### PR DESCRIPTION
bug描述：当我在图形化界面用ctrl选中多个视频的时候，发现处理的时候会弹框报错wrong "be" command line value
bug查找：直接导致这个bug的代码是main.py的第449行
``` python
subprocess.run(cmd, shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
```
其中cmd中输入的值我打印了一下，如下
``` cmd
D:\subtitleExtract\vse-v2.0.3-windows-nvidia-cuda-12.3\resources\backend\subfinder\windows\VideoSubFinderWXW.exe --use_cuda -c -r -i "D:/mypython/speechText/data/jinhua_data/原始音频/永康日报_1l0npmigw7sow__以赛促教展技艺 市中小学教师劳动技能比赛举行.mp4" -o "D:\subtitleExtract\vse-v2.0.3-windows-nvidia-cuda-12.3\resources\output\永康日报_1l0npmigw7sow__以赛促教展技艺 市中小学教师劳动技能比赛举行" -ces "D:\subtitleExtract\vse-v2.0.3-windows-nvidia-cuda-12.3\resources\output\永康日报_1l0npmigw7sow__以赛促教展技艺 市中小学教师劳动技能比赛举行\subtitle\raw_vsf.srt" -te -0.125 -be -0.22916666666666674 -le 0.21875 -re 1.2373046875 -nthr 13 -nocrthr 13
```
可以看到导致bug的原因是-be输入的值是负数，然后经过一番查找
计算be的时候使用的方法是
``` python
        bottom_end = 1 - self.sub_area[1] / self.frame_height
```
frame_height是当前正在处理的视频的分辨率

而sub_area是通过main.py中的
``` python
subtitle_area = (self.ymin, self.ymax, self.xmin, self.xmax)
```
算出来的，但是ymin和ymax和xmin和xmax都是可视化界面的视频的分辨率，而不是当前正在处理的视频的分辨率
bug解决：在传进去开启每个视频的时候，额外根据当前的视频做一次换算，算出正确的比率