### PR TITLE
修复VSF模式下可能丢失字幕

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -378,7 +378,9 @@ class SubtitleExtractor:
                         total_ms = int(ms) + int(s) * 1000 + int(m) * 60 * 1000 + int(h) * 60 * 60 * 1000
                         if total_ms > last_total_ms:
                             frame_no = int(total_ms / self.fps)
-                            task = (self.frame_count, frame_no, None, None, total_ms, self.default_subtitle_area)
+                            # 增加1帧时间，避免cv2截图时可能获取到没字幕的关键帧
+                            frame_time = total_ms + (1000 / self.fps)
+                            task = (self.frame_count, frame_no, None, None, frame_time, self.default_subtitle_area)
                             self.subtitle_ocr_task_queue.put(task)
                         last_total_ms = total_ms
                         if total_ms / duration_ms >= 1:
@@ -403,7 +405,9 @@ class SubtitleExtractor:
                     total_ms = int(ms) + int(s) * 1000 + int(m) * 60 * 1000 + int(h) * 60 * 60 * 1000
                     if total_ms > last_total_ms:
                         frame_no = int(total_ms / self.fps)
-                        task = (self.frame_count, frame_no, None, None, total_ms, self.default_subtitle_area)
+                        # 增加1帧时间，避免cv2截图时可能获取到没字幕的关键帧
+                        frame_time = total_ms + (1000 / self.fps)
+                        task = (self.frame_count, frame_no, None, None, frame_time, self.default_subtitle_area)
                         self.subtitle_ocr_task_queue.put(task)
                     last_total_ms = total_ms
                     if total_ms / duration_ms >= 1:


### PR DESCRIPTION
CV2通过`cv2.CAP_PROP_POS_MSEC`模式提取字幕图片时，可能会获取到指定时间之前的帧，导致CV2截取的图片是缺失字幕的，和实际VSF提取的图片有差异，导致最后OCR后没有字幕。

我的修复方法是简单把VSF字幕时间前移一帧，可能更好的修复方法是直接传VSF的图片数据。