### PR TITLE
Pin PaddlePaddle to 3.2.0 to avoid PIR + OneDNN crash on CPU

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ numpy~=2.2
 shapely~=2.1
 six~=1.17
 setuptools~=80.9
-paddlepaddle~=3.3
-paddleocr~=3.4.0
+paddlepaddle==3.2.0
+paddleocr>=3.3.0,<3.4.0
 je-showinfilemanager==1.1.6a4
 imageio-ffmpeg~=0.6


### PR DESCRIPTION
**Problem**

PaddlePaddle 3.3.0 and 3.3.1 crash on CPU inference with PP-OCRv5 models:

```
(Unimplemented) ConvertPirAttribute2RuntimeAttribute not support
[pir::ArrayAttribute<pir::DoubleAttribute>]
(at onednn_instruction.cc:116)
```

The PIR executor's OneDNN handler is missing a case for `ArrayAttribute<DoubleAttribute>` (used by PP-OCRv5 models). PR PaddlePaddle#77430 fixed this in the `develop` branch (April 2026) but was **never backported to any v3.3.x release**. The app hangs forever at `[Processing] Recognizing subtitle content, please wait...` because the OCR worker crashes silently.

**Fix**

Community-tested working combination: `paddlepaddle==3.2.0` + `paddleocr>=3.3.0`.

```diff
- paddlepaddle~=3.3
- paddleocr~=3.4.0
+ paddlepaddle==3.2.0
+ paddleocr>=3.3.0,<3.4.0
```

Verified 6 language+mode combinations all pass on CPU (ch/en/japan/korean × fast/accurate).

**Files changed:** 1