### PR TITLE
feat: fall back to system ffmpeg when OpenCV can't decode the video

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -1,10 +1,21 @@
-
+import configparser
 import os
 from pathlib import Path
-from qfluentwidgets import (qconfig, ConfigItem, QConfig, OptionsValidator, BoolValidator, OptionsConfigItem, 
-                            EnumSerializer, RangeValidator, RangeConfigItem, ConfigValidator)
+
+from qfluentwidgets import (
+    BoolValidator,
+    ConfigItem,
+    ConfigValidator,
+    EnumSerializer,
+    OptionsConfigItem,
+    OptionsValidator,
+    QConfig,
+    RangeConfigItem,
+    RangeValidator,
+    qconfig,
+)
+
 from backend.tools.constant import SubtitleArea, VideoSubFinderDecoder
-import configparser
 
 # 项目版本号
 VERSION = "2.2.0"
@@ -14,30 +25,39 @@ PROJECT_RELEASES_URL = PROJECT_HOME_URL + "/releases"
 PROJECT_UPDATE_URLS = [
     "https://api.github.com/repos/YaoFANGUK/video-subtitle-extractor/releases/latest",
     "https://accelerate.xdow.net/api/repos/YaoFANGUK/video-subtitle-extractor/releases/latest",
-] 
+]
 # 硬件加速选项开关
 HARDWARD_ACCELERATION_OPTION = True
 
 # 读取界面语言配置
 tr = configparser.ConfigParser()
 
-TRANSLATION_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'interface', f"en.ini")
-tr.read(TRANSLATION_FILE, encoding='utf-8')
+TRANSLATION_FILE = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "interface", "en.ini"
+)
+tr.read(TRANSLATION_FILE, encoding="utf-8")
+
 
 class Config(QConfig):
     # 界面语言设置
     intefaceTexts = {
-        '简体中文': 'ch',
-        '繁體中文': 'chinese_cht',
-        'English': 'en',
-        '한국어': 'ko',
-        '日本語': 'japan',
-        'Tiếng Việt': 'vi',
-        'Español': 'es',
-        'Turkish': 'tr'
+        "简体中文": "ch",
+        "繁體中文": "chinese_cht",
+        "English": "en",
+        "한국어": "ko",
+        "日本語": "japan",
+        "Tiếng Việt": "vi",
+        "Español": "es",
+        "Turkish": "tr",
     }
-    interface = OptionsConfigItem("Window", "Interface", "ChineseSimplified", OptionsValidator(intefaceTexts.values()), restart = True)
-    
+    interface = OptionsConfigItem(
+        "Window",
+        "Interface",
+        "ch",
+        OptionsValidator(intefaceTexts.values()),
+        restart=True,
+    )
+
     # 窗口位置和大小
     windowX = ConfigItem("Window", "X", None)
     windowY = ConfigItem("Window", "Y", None)
@@ -46,68 +66,126 @@ class Config(QConfig):
 
     # 使用一个配置项存储所有选区
     # 默认值为一个选区，格式为："ymin,ymax,xmin,xmax;ymin,ymax,xmin,xmax;..."，分号分隔不同选区
-    subtitleSelectionAreas = ConfigItem("Main", "SubtitleSelectionAreas", "0.78,0.99,0.05,0.95")
+    subtitleSelectionAreas = ConfigItem(
+        "Main", "SubtitleSelectionAreas", "0.78,0.99,0.05,0.95"
+    )
 
     # 字幕语言设置
-    language = OptionsConfigItem("Main", "Language", "ch", OptionsValidator([name for name in tr["Language"]]))
+    language = OptionsConfigItem(
+        "Main", "Language", "ch", OptionsValidator([name for name in tr["Language"]])
+    )
     # 识别模式设置
-    mode = OptionsConfigItem("Main", "Mode", "fast",  OptionsValidator(["auto", "fast", "accurate"]))
+    mode = OptionsConfigItem(
+        "Main", "Mode", "fast", OptionsValidator(["auto", "fast", "accurate"])
+    )
     # 是否生成TXT文本字幕
     generateTxt = ConfigItem("Main", "GenerateTxt", False, BoolValidator())
     # 每张图中同时识别6个文本框中的文本，GPU显存越大，该数值可以设置越大
-    recBatchNumber = RangeConfigItem("Main", "RecBatchNumber", 6, RangeValidator(1, 100))
+    recBatchNumber = RangeConfigItem(
+        "Main", "RecBatchNumber", 6, RangeValidator(1, 100)
+    )
     # DB算法每个batch识别多少张，默认为10
     maxBatchSize = RangeConfigItem("Main", "MaxBatchSize", 10, RangeValidator(1, 256))
     # 字幕出现区域
-    subtitleArea = OptionsConfigItem("Main", "SubtitleArea", SubtitleArea.UNKNOWN, OptionsValidator(SubtitleArea), EnumSerializer(SubtitleArea))
+    subtitleArea = OptionsConfigItem(
+        "Main",
+        "SubtitleArea",
+        SubtitleArea.UNKNOWN,
+        OptionsValidator(SubtitleArea),
+        EnumSerializer(SubtitleArea),
+    )
     # 每一秒抓取多少帧进行OCR识别
-    extractFrequency = RangeConfigItem("Main", "ExtractFrequency", 3, RangeValidator(1, 60))
+    extractFrequency = RangeConfigItem(
+        "Main", "ExtractFrequency", 3, RangeValidator(1, 60)
+    )
     # 容忍的像素点偏差
-    tolerantPixelY = RangeConfigItem("Main", "TolerantPixelY", 50, RangeValidator(1, 1000))
-    tolerantPixelX = RangeConfigItem("Main", "TolerantPixelX", 100, RangeValidator(1, 1000))
+    tolerantPixelY = RangeConfigItem(
+        "Main", "TolerantPixelY", 50, RangeValidator(1, 1000)
+    )
+    tolerantPixelX = RangeConfigItem(
+        "Main", "TolerantPixelX", 100, RangeValidator(1, 1000)
+    )
     # 字幕区域偏移量
-    subtitleAreaDeviationPixel = RangeConfigItem("Main", "SubtitleAreaDeviationPixel", 50, RangeValidator(1, 1000))
+    subtitleAreaDeviationPixel = RangeConfigItem(
+        "Main", "SubtitleAreaDeviationPixel", 50, RangeValidator(1, 1000)
+    )
     # 最有可能出现的水印区域
-    waterarkAreaNum = RangeConfigItem("Main", "WaterarkAreaNum", 5, RangeValidator(1, 10))
+    waterarkAreaNum = RangeConfigItem(
+        "Main", "WaterarkAreaNum", 5, RangeValidator(1, 10)
+    )
     # 文本相似度阈值
     # 用于去重时判断两行字幕是不是同一行，这个值越高越严格。 e.g. 0.99表示100个字里面有99各个字一模一样才算相似
     # 采用动态算法实现相似度阈值判断: 对于短文本要求较低的阈值，对于长文本要求较高的阈值
     # 如：文本较短，人民、入民，0.5就算相似
-    thresholdTextSimilarity = RangeConfigItem("Main", "ThresholdTextSimilarity", 80, RangeValidator(0, 100))
+    thresholdTextSimilarity = RangeConfigItem(
+        "Main", "ThresholdTextSimilarity", 80, RangeValidator(0, 100)
+    )
     # 字幕提取中置信度低于0.75的不要
     dropScore = RangeConfigItem("Main", "DropScore", 75, RangeValidator(0, 100))
     # 字幕区域允许偏差, 0为不允许越界, 0.03表示可以越界3%
-    subtitleAreaDeviationRate = RangeConfigItem("Main", "SubtitleAreaDeviationRate", 0, RangeValidator(0, 100))
+    subtitleAreaDeviationRate = RangeConfigItem(
+        "Main", "SubtitleAreaDeviationRate", 0, RangeValidator(0, 100)
+    )
     # 输出丢失的字幕帧, 仅简体中文,繁体中文,日文,韩语有效, 默认将调试信息输出到: 视频路径/loss
     debugOcrLoss = ConfigItem("Main", "DebugOcrLoss", False, BoolValidator())
     # 是否不删除缓存数据，以方便调试
-    debugNoDeleteCache = ConfigItem("Main", "DebugNoDeleteCache", False, BoolValidator())
+    debugNoDeleteCache = ConfigItem(
+        "Main", "DebugNoDeleteCache", False, BoolValidator()
+    )
     # 是否删除空时间轴
-    deleteEmptyTimeStamp = ConfigItem("Main", "DeleteEmptyTimeStamp", True, BoolValidator())
+    deleteEmptyTimeStamp = ConfigItem(
+        "Main", "DeleteEmptyTimeStamp", True, BoolValidator()
+    )
     # 是否重新分词, 用于解决没有语句没有空格
     wordSegmentation = ConfigItem("Main", "WordSegmentation", True, BoolValidator())
     # 是否使用硬件加速
-    hardwareAcceleration = ConfigItem("Main", "HardwareAcceleration", HARDWARD_ACCELERATION_OPTION, BoolValidator())
+    hardwareAcceleration = ConfigItem(
+        "Main", "HardwareAcceleration", HARDWARD_ACCELERATION_OPTION, BoolValidator()
+    )
     # 启动时检查应用更新
-    checkUpdateOnStartup = ConfigItem("Main", "CheckUpdateOnStartup", True, BoolValidator())
+    checkUpdateOnStartup = ConfigItem(
+        "Main", "CheckUpdateOnStartup", True, BoolValidator()
+    )
     # 视频保存目录
     saveDirectory = ConfigItem("Main", "SaveDirectory", "", ConfigValidator())
     # VideoSubFinder CPU核心数
-    videoSubFinderCpuCores = RangeConfigItem("Main", "VideoSubFinderCpuCores", 0, RangeValidator(0, os.cpu_count()))
+    videoSubFinderCpuCores = RangeConfigItem(
+        "Main", "VideoSubFinderCpuCores", 0, RangeValidator(0, os.cpu_count())
+    )
     # VideoSubFinder 视频解码组件
-    videoSubFinderDecoder = OptionsConfigItem("Main", "VideoSubFinderDecoder", VideoSubFinderDecoder.OPENCV, OptionsValidator(VideoSubFinderDecoder), EnumSerializer(VideoSubFinderDecoder))
+    videoSubFinderDecoder = OptionsConfigItem(
+        "Main",
+        "VideoSubFinderDecoder",
+        VideoSubFinderDecoder.OPENCV,
+        OptionsValidator(VideoSubFinderDecoder),
+        EnumSerializer(VideoSubFinderDecoder),
+    )
 
-CONFIG_FILE = 'config/config.json'
+
+CONFIG_FILE = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "..", "config", "config.json"
+)
 config = Config()
 qconfig.load(CONFIG_FILE, config)
 
-# 读取界面语言配置
+# 读取界面语言配置 — 先加载 en.ini 作为后备，再叠加用户语言
 tr = configparser.ConfigParser()
 
-TRANSLATION_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'interface', f"{config.interface.value}.ini")
-tr.read(TRANSLATION_FILE, encoding='utf-8')
+# 基础: 始终加载英文翻译作为后备
+EN_TRANSLATION_FILE = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "interface", "en.ini"
+)
+tr.read(EN_TRANSLATION_FILE, encoding="utf-8")
+
+# 叠加: 用户选择的语言覆盖英文后备中的对应键值
+user_lang = config.interface.value
+if user_lang != "en":
+    USER_TRANSLATION_FILE = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "interface", f"{user_lang}.ini"
+    )
+    tr.read(USER_TRANSLATION_FILE, encoding="utf-8")
 
 # 项目的base目录
 BASE_DIR = str(Path(os.path.abspath(__file__)).parent)
 
-os.environ['KMP_DUPLICATE_LIB_OK'] = 'True'
+os.environ["KMP_DUPLICATE_LIB_OK"] = "True"

--- a/backend/main.py
+++ b/backend/main.py
@@ -5,38 +5,42 @@
 @FileName: main.py
 @desc: 主程序入口文件
 """
+
 import os
-import re
 import random
+import re
 import shutil
+import sys
 import traceback
-from collections import Counter, namedtuple
 import unicodedata
-from threading import Thread
+from collections import Counter, namedtuple
 from pathlib import Path
+from threading import Thread
+
 import cv2
 from Levenshtein import ratio
-from PIL import Image
 from numpy import average, dot, linalg
+from PIL import Image
 from tqdm import tqdm
-import sys
 
 sys.path.insert(0, os.path.dirname(__file__))
+import multiprocessing
+import platform
 import subprocess
+import threading
+import time
+
+import pysrt
+
+from backend.bean.subtitle_area import SubtitleArea
 from backend.config import *
+from backend.tools import reformat, subtitle_ocr
 from backend.tools.hardware_accelerator import HardwareAccelerator
-from backend.tools import reformat
 from backend.tools.ocr import OcrRecogniser, get_coordinates
-from backend.tools import subtitle_ocr
 from backend.tools.paddle_model_config import PaddleModelConfig
 from backend.tools.process_manager import ProcessManager
 from backend.tools.subtitle_detect import SubtitleDetect
-from backend.bean.subtitle_area import SubtitleArea
-import threading
-import platform
-import multiprocessing
-import time
-import pysrt
+
 
 class SubtitleExtractor:
     """
@@ -60,7 +64,9 @@ class SubtitleExtractor:
         # 通过视频路径获取视频名称
         self.vd_name = Path(self.video_path).stem
         # 临时存储文件夹
-        self.temp_output_dir = os.path.join(os.path.dirname(BASE_DIR), 'output', str(self.vd_name))
+        self.temp_output_dir = os.path.join(
+            os.path.dirname(BASE_DIR), "output", str(self.vd_name)
+        )
         # 视频帧总数
         self.frame_count = self.video_cap.get(cv2.CAP_PROP_FRAME_COUNT)
         # 视频帧率
@@ -69,17 +75,17 @@ class SubtitleExtractor:
         self.frame_height = int(self.video_cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
         self.frame_width = int(self.video_cap.get(cv2.CAP_PROP_FRAME_WIDTH))
         # 提取的视频帧储存目录
-        self.frame_output_dir = os.path.join(self.temp_output_dir, 'frames')
+        self.frame_output_dir = os.path.join(self.temp_output_dir, "frames")
         # 提取的字幕文件存储目录
-        self.subtitle_output_dir = os.path.join(self.temp_output_dir, 'subtitle')
+        self.subtitle_output_dir = os.path.join(self.temp_output_dir, "subtitle")
         # 定义是否使用vsf提取字幕帧
         self.use_vsf = False
         # 定义vsf的字幕输出路径
-        self.vsf_subtitle = os.path.join(self.subtitle_output_dir, 'raw_vsf.srt')
+        self.vsf_subtitle = os.path.join(self.subtitle_output_dir, "raw_vsf.srt")
         # 提取的原始字幕文本存储路径
-        self.raw_subtitle_path = os.path.join(self.subtitle_output_dir, 'raw.txt')
+        self.raw_subtitle_path = os.path.join(self.subtitle_output_dir, "raw.txt")
         # 定义输出字幕文件路径
-        self.subtitle_output_path = os.path.splitext(self.video_path)[0] + '.srt'
+        self.subtitle_output_path = os.path.splitext(self.video_path)[0] + ".srt"
         # 自定义ocr对象
         self.ocr = None
         # 总处理进度（帧提取100 + OCR100 + 后处理100 = 300）
@@ -110,21 +116,29 @@ class SubtitleExtractor:
         self.lock.acquire()
         # 重置进度条
         self.update_progress(ocr=0, frame_extract=0, post=0)
-        self.append_output('-----------------------------')
+        self.append_output("-----------------------------")
         # 打印识别语言与识别模式
-        self.append_output(f"  {tr['Main']['RecSubLang']}：{config.language.value}  |  {tr['Main']['RecMode']}：{config.mode.value}")
+        self.append_output(
+            f"  {tr['Main']['RecSubLang']}：{config.language.value}  |  {tr['Main']['RecMode']}：{config.mode.value}"
+        )
         # 如果使用GPU加速，则打印GPU加速提示
         if self.hardware_accelerator.has_accelerator():
-            self.append_output(f"  {tr['Main']['AcceleratorON'].format(self.hardware_accelerator.accelerator_name)}")
+            self.append_output(
+                f"  {tr['Main']['AcceleratorON'].format(self.hardware_accelerator.accelerator_name)}"
+            )
 
         # 打印视频帧数与帧率
-        self.append_output(f"  {tr['Main']['FrameCount']}：{self.frame_count}"
-              f"  |  {tr['Main']['FrameRate']}：{self.fps}")
+        self.append_output(
+            f"  {tr['Main']['FrameCount']}：{self.frame_count}"
+            f"  |  {tr['Main']['FrameRate']}：{self.fps}"
+        )
         # 打印加载模型信息
-        self.append_output(f"  DET: {os.path.basename(self.model_config.DET_MODEL_PATH)}  |  REC: {os.path.basename(self.model_config.REC_MODEL_PATH)}")
-        self.append_output('-----------------------------')
+        self.append_output(
+            f"  DET: {os.path.basename(self.model_config.DET_MODEL_PATH)}  |  REC: {os.path.basename(self.model_config.REC_MODEL_PATH)}"
+        )
+        self.append_output("-----------------------------")
         # 打印视频帧提取开始提示
-        self.append_output(tr['Main']['StartProcessFrame'])
+        self.append_output(tr["Main"]["StartProcessFrame"])
         # 删除缓存
         self.__delete_frame_cache()
         # 若目录不存在，则创建文件夹
@@ -134,11 +148,30 @@ class SubtitleExtractor:
             os.makedirs(self.subtitle_output_dir)
         self.capture_frame_with_subtitle_area()
         # 创建一个字幕OCR识别进程
-        subtitle_ocr_process = self.start_subtitle_ocr_async()
+        # VSF裁剪帧到字幕区域，OCR不需要再过滤；DET/FPS不裁剪，需要OCR过滤
         if self.sub_area is not None:
-            if platform.system() in ['Windows', 'Linux', 'Darwin']:
+            if platform.system() in ["Windows", "Linux", "Darwin"]:
+                if (
+                    self.hardware_accelerator.has_accelerator()
+                    and config.mode.value == "accurate"
+                ):
+                    use_vsf = False
+                else:
+                    use_vsf = True
+            else:
+                use_vsf = False
+        else:
+            use_vsf = False
+        subtitle_ocr_process = self.start_subtitle_ocr_async(
+            filter_sub_area=None if use_vsf else self.sub_area
+        )
+        if self.sub_area is not None:
+            if platform.system() in ["Windows", "Linux", "Darwin"]:
                 # 使用GPU且使用accurate模式时才开放此方法：
-                if self.hardware_accelerator.has_accelerator() and config.mode.value == 'accurate':
+                if (
+                    self.hardware_accelerator.has_accelerator()
+                    and config.mode.value == "accurate"
+                ):
                     self.extract_frame_by_det()
                 else:
                     self.extract_frame_by_vsf()
@@ -153,28 +186,28 @@ class SubtitleExtractor:
         # 等待子线程完成
         subtitle_ocr_process.join()
         # 打印完成提示
-        self.append_output(tr['Main']['FinishProcessFrame'])
-        self.append_output(tr['Main']['FinishFindSub'])
+        self.append_output(tr["Main"]["FinishProcessFrame"])
+        self.append_output(tr["Main"]["FinishFindSub"])
 
         if self.sub_area is None:
-            self.append_output(tr['Main']['StartDetectWaterMark'])
+            self.append_output(tr["Main"]["StartDetectWaterMark"])
             # 询问用户视频是否有水印区域
-            user_input = input(tr['Main']['checkWaterMark']).strip()
-            if user_input == 'y':
+            user_input = input(tr["Main"]["checkWaterMark"]).strip()
+            if user_input == "y":
                 self.filter_watermark()
-                self.append_output(tr['Main']['FinishDetectWaterMark'])
+                self.append_output(tr["Main"]["FinishDetectWaterMark"])
             else:
-                self.append_output('-----------------------------')
+                self.append_output("-----------------------------")
 
         if self.sub_area is None:
-            self.append_output(tr['Main']['StartDeleteNonSub'])
+            self.append_output(tr["Main"]["StartDeleteNonSub"])
             self.filter_scene_text()
-            self.append_output(tr['Main']['FinishDeleteNonSub'])
+            self.append_output(tr["Main"]["FinishDeleteNonSub"])
 
         self.update_progress(post=20)
 
         # 打印开始字幕生成提示
-        self.append_output(tr['Main']['StartGenerateSub'])
+        self.append_output(tr["Main"]["StartGenerateSub"])
         # 判断是否使用了vsf提取字幕
         if self.use_vsf:
             # 如果使用了vsf提取字幕，则使用vsf的字幕生成方法
@@ -187,8 +220,10 @@ class SubtitleExtractor:
 
         if config.wordSegmentation.value:
             reformat.execute(self.subtitle_output_path, config.language.value)
-        self.append_output(tr['Main']['FinishGenerateSub'], f"{round(time.time() - start_time, 2)}s")
-        self.append_output('-----------------------------')
+        self.append_output(
+            tr["Main"]["FinishGenerateSub"], f"{round(time.time() - start_time, 2)}s"
+        )
+        self.append_output("-----------------------------")
         self.update_progress(ocr=100, frame_extract=100, post=100)
         self.isFinished = True
         # 删除缓存文件
@@ -204,31 +239,44 @@ class SubtitleExtractor:
         # 确保输出目录存在
         if not os.path.exists(self.temp_output_dir):
             os.makedirs(self.temp_output_dir)
-            
+
         # 确保视频已打开
         if not self.video_cap.isOpened():
             self.video_cap = cv2.VideoCapture(self.video_path)
-            
+
         # 将视频指针设置到第一帧
         # self.video_cap.set(cv2.CAP_PROP_POS_FRAMES, 0)
-        
+
         # 读取第一帧
         ret, frame = self.video_cap.read()
-        
+
         if ret:
             # 如果有字幕区域，绘制矩形
             sub_area = self.sub_area
             if sub_area is not None:
                 # 绘制绿色矩形框
-                cv2.rectangle(frame, (sub_area.xmin, sub_area.ymin), (sub_area.xmax, sub_area.ymax), (0, 255, 0), 2)
+                cv2.rectangle(
+                    frame,
+                    (sub_area.xmin, sub_area.ymin),
+                    (sub_area.xmax, sub_area.ymax),
+                    (0, 255, 0),
+                    2,
+                )
                 # 添加文字标注
-                cv2.putText(frame, "Subtitle Area", (sub_area.xmin, sub_area.ymin - 10), 
-                           cv2.FONT_HERSHEY_SIMPLEX, 0.9, (0, 255, 0), 2)
-            
+                cv2.putText(
+                    frame,
+                    "Subtitle Area",
+                    (sub_area.xmin, sub_area.ymin - 10),
+                    cv2.FONT_HERSHEY_SIMPLEX,
+                    0.9,
+                    (0, 255, 0),
+                    2,
+                )
+
             # 保存图像
-            output_path = os.path.join(self.temp_output_dir, 'sub_area.jpg')
+            output_path = os.path.join(self.temp_output_dir, "sub_area.jpg")
             cv2.imwrite(output_path, frame)
-            
+
             # 重置视频指针到第一帧
             self.video_cap.set(cv2.CAP_PROP_POS_FRAMES, 0)
 
@@ -251,10 +299,19 @@ class SubtitleExtractor:
                 break
             current_frame_no += 1
             # subtitle_ocr_task_queue: (total_frame_count总帧数, current_frame_no当前帧, dt_box检测框, rec_res识别结果, 当前帧时间，subtitle_area字幕区域)
-            task = (self.frame_count, current_frame_no, None, None, None, config.subtitleArea.value)
+            task = (
+                self.frame_count,
+                current_frame_no,
+                None,
+                None,
+                None,
+                config.subtitleArea.value,
+            )
             self.subtitle_ocr_task_queue.put(task)
             # 更新进度条
-            self.update_progress(frame_extract=(current_frame_no / self.frame_count) * 100)
+            self.update_progress(
+                frame_extract=(current_frame_no / self.frame_count) * 100
+            )
             # 跳到下一个采样帧
             current_frame_no = current_frame_no + frame_interval - 1
 
@@ -271,7 +328,9 @@ class SubtitleExtractor:
         frame_lru_list_max_size = 2
         ocr_args_list = []
         compare_ocr_result_cache = {}
-        tbar = tqdm(total=int(self.frame_count), unit='f', position=0, file=sys.__stdout__)
+        tbar = tqdm(
+            total=int(self.frame_count), unit="f", position=0, file=sys.__stdout__
+        )
         first_flag = True
         is_finding_start_frame_no = False
         is_finding_end_frame_no = False
@@ -296,9 +355,12 @@ class SubtitleExtractor:
                 if coordinate_list:
                     for coordinate in coordinate_list:
                         xmin, xmax, ymin, ymax = coordinate
-                        if (sub_area.xmin <= xmin and xmax <= sub_area.xmax
-                                and sub_area.ymin <= ymin
-                                and ymax <= sub_area.ymax):
+                        if (
+                            sub_area.xmin <= xmin
+                            and xmax <= sub_area.xmax
+                            and sub_area.ymin <= ymin
+                            and ymax <= sub_area.ymax
+                        ):
                             has_subtitle = True
                             # 检测到字幕时，如果列表为空，则为字幕头
                             if first_flag:
@@ -315,7 +377,11 @@ class SubtitleExtractor:
                     dt_box, rec_res = self.ocr.predict(frame)
                     area_text1 = "".join(self.__get_area_text((dt_box, rec_res)))
                     if start_frame_no not in compare_ocr_result_cache.keys():
-                        compare_ocr_result_cache[current_frame_no] = {'text': area_text1, 'dt_box': dt_box, 'rec_res': rec_res}
+                        compare_ocr_result_cache[current_frame_no] = {
+                            "text": area_text1,
+                            "dt_box": dt_box,
+                            "rec_res": rec_res,
+                        }
                         frame_lru_list.append((frame, current_frame_no))
                         ocr_args_list.append((self.frame_count, current_frame_no))
                         # 缓存头帧
@@ -334,7 +400,13 @@ class SubtitleExtractor:
                 # 如果在找结束帧的时候
                 if is_finding_end_frame_no:
                     # 判断该帧与头帧ocr内容是否一致,若不一致则找到尾，尾巴为前一帧
-                    if not self._compare_ocr_result(compare_ocr_result_cache, None, start_frame_no, frame, current_frame_no):
+                    if not self._compare_ocr_result(
+                        compare_ocr_result_cache,
+                        None,
+                        start_frame_no,
+                        frame,
+                        current_frame_no,
+                    ):
                         is_finding_end_frame_no = False
                         is_finding_start_frame_no = True
                         end_frame_no = current_frame_no - 1
@@ -356,47 +428,67 @@ class SubtitleExtractor:
                 frame_lru_list.pop(0)
 
             # if len(start_end_frame_no) > 0:
-                # self.append_output(start_end_frame_no)
+            # self.append_output(start_end_frame_no)
 
             while len(ocr_args_list) > 1:
                 total_frame_count, ocr_info_frame_no = ocr_args_list.pop(0)
                 if current_frame_no in compare_ocr_result_cache:
                     predict_result = compare_ocr_result_cache[current_frame_no]
-                    dt_box, rec_res = predict_result['dt_box'], predict_result['rec_res']
+                    dt_box, rec_res = (
+                        predict_result["dt_box"],
+                        predict_result["rec_res"],
+                    )
                 else:
                     dt_box, rec_res = None, None
                 # subtitle_ocr_task_queue: (total_frame_count总帧数, current_frame_no当前帧, dt_box检测框, rec_res识别结果, 当前帧时间， subtitle_area字幕区域)
-                task = (total_frame_count, ocr_info_frame_no, dt_box, rec_res, None, config.subtitleArea.value)
+                task = (
+                    total_frame_count,
+                    ocr_info_frame_no,
+                    dt_box,
+                    rec_res,
+                    None,
+                    config.subtitleArea.value,
+                )
                 # 添加任务
                 self.subtitle_ocr_task_queue.put(task)
-                self.update_progress(frame_extract=(current_frame_no / self.frame_count) * 100)
+                self.update_progress(
+                    frame_extract=(current_frame_no / self.frame_count) * 100
+                )
 
         while len(ocr_args_list) > 0:
             total_frame_count, ocr_info_frame_no = ocr_args_list.pop(0)
             if current_frame_no in compare_ocr_result_cache:
                 predict_result = compare_ocr_result_cache[current_frame_no]
-                dt_box, rec_res = predict_result['dt_box'], predict_result['rec_res']
+                dt_box, rec_res = predict_result["dt_box"], predict_result["rec_res"]
             else:
                 dt_box, rec_res = None, None
-            task = (total_frame_count, ocr_info_frame_no, dt_box, rec_res, None, config.subtitleArea.value)
+            task = (
+                total_frame_count,
+                ocr_info_frame_no,
+                dt_box,
+                rec_res,
+                None,
+                config.subtitleArea.value,
+            )
             # 添加任务
             self.subtitle_ocr_task_queue.put(task)
         self.video_cap.release()
 
     def extract_frame_by_vsf(self):
         """
-       通过调用videoSubFinder获取字幕帧
-       """
+        通过调用videoSubFinder获取字幕帧
+        """
         self.use_vsf = True
         if self.video_cap:
             self.video_cap.release()
             self.video_cap = None
+
         def count_process():
             duration_ms = (self.frame_count / self.fps) * 1000
             last_total_ms = 0
             processed_image = set()
-            rgb_images_path = os.path.join(self.temp_output_dir, 'RGBImages')
-            time_pattern = re.compile(r'^\d+_\d+_\d+_\d+__')
+            rgb_images_path = os.path.join(self.temp_output_dir, "RGBImages")
+            time_pattern = re.compile(r"^\d+_\d+_\d+_\d+__")
             while self.vsf_running and not self.isFinished:
                 time.sleep(0.2)
                 # 如果还没有rgb_images_path说明vsf还没处理完
@@ -415,55 +507,89 @@ class SubtitleExtractor:
                         # self.append_output('rgb_image: ', rgb_image)
                         processed_image.add(rgb_image)
                         # 根据vsf生成的文件名读取时间
-                        h, m, s, ms = rgb_image.split('__')[0].split('_')
-                        total_ms = int(ms) + int(s) * 1000 + int(m) * 60 * 1000 + int(h) * 60 * 60 * 1000
+                        h, m, s, ms = rgb_image.split("__")[0].split("_")
+                        total_ms = (
+                            int(ms)
+                            + int(s) * 1000
+                            + int(m) * 60 * 1000
+                            + int(h) * 60 * 60 * 1000
+                        )
                         if total_ms > last_total_ms:
                             frame_no = int(total_ms / self.fps)
-                            task = (self.frame_count, frame_no, None, None, total_ms, config.subtitleArea.value)
+                            task = (
+                                self.frame_count,
+                                frame_no,
+                                None,
+                                None,
+                                total_ms,
+                                config.subtitleArea.value,
+                            )
                             self.subtitle_ocr_task_queue.put(task)
                         last_total_ms = total_ms
                         if total_ms / duration_ms >= 1:
                             self.update_progress(frame_extract=100)
                             return
                         else:
-                            self.update_progress(frame_extract=(total_ms / duration_ms) * 100)
+                            self.update_progress(
+                                frame_extract=(total_ms / duration_ms) * 100
+                            )
                 # 文件被清理了
                 except FileNotFoundError:
                     return
 
-        def vsf_output(out, ):
+        def vsf_output(
+            out,
+        ):
             duration_ms = (self.frame_count / self.fps) * 1000
             last_total_ms = 0
-            for line in iter(out.readline, b''):
+            for line in iter(out.readline, b""):
                 line = line.decode("utf-8")
                 # self.append_output('line', line, type(line), line.startswith('Frame: '))
-                if line.startswith('Frame: '):
+                if line.startswith("Frame: "):
                     line = line.replace("\n", "")
                     line = line.replace("Frame: ", "")
-                    h, m, s, ms = line.split('__')[0].split('_')
-                    total_ms = int(ms) + int(s) * 1000 + int(m) * 60 * 1000 + int(h) * 60 * 60 * 1000
+                    h, m, s, ms = line.split("__")[0].split("_")
+                    total_ms = (
+                        int(ms)
+                        + int(s) * 1000
+                        + int(m) * 60 * 1000
+                        + int(h) * 60 * 60 * 1000
+                    )
                     if total_ms > last_total_ms:
                         frame_no = int(total_ms / self.fps)
-                        task = (self.frame_count, frame_no, None, None, total_ms, config.subtitleArea.value)
+                        task = (
+                            self.frame_count,
+                            frame_no,
+                            None,
+                            None,
+                            total_ms,
+                            config.subtitleArea.value,
+                        )
                         self.subtitle_ocr_task_queue.put(task)
                     last_total_ms = total_ms
                     if total_ms / duration_ms >= 1:
                         self.update_progress(frame_extract=100)
                         return
                     else:
-                        self.update_progress(frame_extract=(total_ms / duration_ms) * 100)
+                        self.update_progress(
+                            frame_extract=(total_ms / duration_ms) * 100
+                        )
                 else:
                     self.append_output(line.strip())
             out.close()
 
         # 定义videoSubFinder所在路径
-        if platform.system() == 'Windows':
-            path_vsf = os.path.join(BASE_DIR, 'subfinder', 'windows', 'VideoSubFinderWXW.exe')
-        elif platform.system() == 'Darwin':
-            path_vsf = os.path.join(BASE_DIR, 'subfinder', 'macos', 'VideoSubFinderCli')
+        if platform.system() == "Windows":
+            path_vsf = os.path.join(
+                BASE_DIR, "subfinder", "windows", "VideoSubFinderWXW.exe"
+            )
+        elif platform.system() == "Darwin":
+            path_vsf = os.path.join(BASE_DIR, "subfinder", "macos", "VideoSubFinderCli")
             os.chmod(path_vsf, 0o775)
         else:
-            path_vsf = os.path.join(BASE_DIR, 'subfinder', 'linux', 'VideoSubFinderCli.run')
+            path_vsf = os.path.join(
+                BASE_DIR, "subfinder", "linux", "VideoSubFinderCli.run"
+            )
             os.chmod(path_vsf, 0o775)
         # ：图像上半部分所占百分比，取值【0-1】
         top_end = 1 - self.sub_area.ymin / self.frame_height
@@ -473,25 +599,34 @@ class SubtitleExtractor:
         left_end = self.sub_area.xmin / self.frame_width
         # re：图像右半部分所占百分比，取值【0-1】
         right_end = self.sub_area.xmax / self.frame_width
-        if (not self.hardware_accelerator.has_cuda()) and len(self.hardware_accelerator.onnx_providers) > 0:
+        if (not self.hardware_accelerator.has_cuda()) and len(
+            self.hardware_accelerator.onnx_providers
+        ) > 0:
             cpu_count = multiprocessing.cpu_count()
         else:
             # 留2核心来给其他任务使用
             cpu_count = max(multiprocessing.cpu_count() - 2, 1)
         if config.videoSubFinderCpuCores.value > 0:
             cpu_count = config.videoSubFinderCpuCores.value
-        if platform.system() == 'Windows':
+        if platform.system() == "Windows":
             # 定义执行命令
-            cmd = f"{path_vsf} --use_cuda -c -r -i \"{self.video_path}\" -o \"{self.temp_output_dir}\" -ces \"{self.vsf_subtitle}\" "
+            cmd = f'{path_vsf} --use_cuda -c -r -i "{self.video_path}" -o "{self.temp_output_dir}" -ces "{self.vsf_subtitle}" '
             cmd += f"-te {top_end} -be {bottom_end} -le {left_end} -re {right_end} -nthr {cpu_count} -nocrthr {cpu_count} "
             cmd += f"--open_video_{config.videoSubFinderDecoder.value.value.lower()} "
             # 计算进度
             try:
                 self.vsf_running = True
-                Thread(target=count_process, daemon=True).start()       
+                Thread(target=count_process, daemon=True).start()
                 # 已知BUG: test_chinese_cht.flv在net drive上会导致无法停止, 但在本地不会, 可能是vsf的原因
-                p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, bufsize=1,
-                                    close_fds='posix' in sys.builtin_module_names, shell=False, creationflags=subprocess.CREATE_NEW_PROCESS_GROUP)
+                p = subprocess.Popen(
+                    cmd,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    bufsize=1,
+                    close_fds="posix" in sys.builtin_module_names,
+                    shell=False,
+                    creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,
+                )
                 ProcessManager.instance().add_process(p)
                 self.manage_process(p.pid)
                 p.wait()
@@ -499,22 +634,29 @@ class SubtitleExtractor:
                 self.vsf_running = False
         else:
             # 定义执行命令
-            cmd = f"{path_vsf} -c -r -i \"{self.video_path}\" -o \"{self.temp_output_dir}\" -ces \"{self.vsf_subtitle}\" "
+            cmd = f'{path_vsf} -c -r -i "{self.video_path}" -o "{self.temp_output_dir}" -ces "{self.vsf_subtitle}" '
             if self.hardware_accelerator.has_accelerator():
                 cmd += "--use_cuda "
             cmd += f"-te {top_end} -be {bottom_end} -le {left_end} -re {right_end} -nthr {cpu_count} -dsi "
             cmd += f"--open_video_{config.videoSubFinderDecoder.value.value.lower()} "
             self.vsf_running = True
             try:
-                p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, bufsize=1,
-                                    close_fds='posix' in sys.builtin_module_names, shell=True,
-                                    start_new_session=True)
+                p = subprocess.Popen(
+                    cmd,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    bufsize=1,
+                    close_fds="posix" in sys.builtin_module_names,
+                    shell=True,
+                    start_new_session=True,
+                )
                 Thread(target=vsf_output, daemon=True, args=(p.stderr,)).start()
                 ProcessManager.instance().add_process(p)
                 self.manage_process(p.pid)
                 p.wait()
             finally:
                 self.vsf_running = False
+
     def filter_watermark(self):
         """
         去除原始字幕文本中的水印区域的文本
@@ -526,7 +668,9 @@ class SubtitleExtractor:
         cap = cv2.VideoCapture(self.video_path)
         ret, sample_frame = False, None
         for i in range(10):
-            frame_no = random.randint(int(self.frame_count * 0.1), int(self.frame_count * 0.9))
+            frame_no = random.randint(
+                int(self.frame_count * 0.1), int(self.frame_count * 0.9)
+            )
             cap.set(cv2.CAP_PROP_POS_FRAMES, frame_no)
             ret, sample_frame = cap.read()
             if ret:
@@ -538,7 +682,7 @@ class SubtitleExtractor:
             return
 
         # 给潜在的水印区域编号
-        area_num = ['E', 'D', 'C', 'B', 'A']
+        area_num = ["E", "D", "C", "B", "A"]
 
         for watermark_area in watermark_areas:
             ymin = min(watermark_area[0][2], watermark_area[0][3])
@@ -547,31 +691,48 @@ class SubtitleExtractor:
             xmax = max(watermark_area[0][1], watermark_area[0][0])
             cover = sample_frame[ymin:ymax, xmin:xmax]
             cover = cv2.blur(cover, (10, 10))
-            cv2.rectangle(cover, pt1=(0, cover.shape[0]), pt2=(cover.shape[1], 0), color=(0, 0, 255), thickness=3)
+            cv2.rectangle(
+                cover,
+                pt1=(0, cover.shape[0]),
+                pt2=(cover.shape[1], 0),
+                color=(0, 0, 255),
+                thickness=3,
+            )
             sample_frame[ymin:ymax, xmin:xmax] = cover
             position = ((xmin + xmax) // 2, ymax)
 
-            cv2.putText(sample_frame, text=area_num.pop(), org=position, fontFace=cv2.FONT_HERSHEY_SIMPLEX,
-                        fontScale=1, color=(255, 0, 0), thickness=2, lineType=cv2.LINE_AA)
+            cv2.putText(
+                sample_frame,
+                text=area_num.pop(),
+                org=position,
+                fontFace=cv2.FONT_HERSHEY_SIMPLEX,
+                fontScale=1,
+                color=(255, 0, 0),
+                thickness=2,
+                lineType=cv2.LINE_AA,
+            )
 
-        sample_frame_file_path = os.path.join(os.path.dirname(self.frame_output_dir), 'watermark_area.jpg')
+        sample_frame_file_path = os.path.join(
+            os.path.dirname(self.frame_output_dir), "watermark_area.jpg"
+        )
         cv2.imwrite(sample_frame_file_path, sample_frame)
         self.append_output(f"{tr['Main']['WatchPicture']}: {sample_frame_file_path}")
 
-        area_num = ['E', 'D', 'C', 'B', 'A']
+        area_num = ["E", "D", "C", "B", "A"]
         for watermark_area in watermark_areas:
-            user_input = input(f"{area_num.pop()}{str(watermark_area)} "
-                               f"{tr['Main']['QuestionDelete']}").strip()
-            if user_input == 'y' or user_input == '\n':
-                with open(self.raw_subtitle_path, mode='r+', encoding='utf-8') as f:
+            user_input = input(
+                f"{area_num.pop()}{str(watermark_area)} {tr['Main']['QuestionDelete']}"
+            ).strip()
+            if user_input == "y" or user_input == "\n":
+                with open(self.raw_subtitle_path, mode="r+", encoding="utf-8") as f:
                     content = f.readlines()
                     f.seek(0)
                     for i in content:
                         if i.find(str(watermark_area[0])) == -1:
                             f.write(i)
                     f.truncate()
-                self.append_output(tr['Main']['FinishDelete'])
-        self.append_output(tr['Main']['FinishWaterMarkFilter'])
+                self.append_output(tr["Main"]["FinishDelete"])
+        self.append_output(tr["Main"]["FinishWaterMarkFilter"])
         # 删除缓存
         if os.path.exists(sample_frame_file_path):
             os.remove(sample_frame_file_path)
@@ -587,7 +748,9 @@ class SubtitleExtractor:
         cap = cv2.VideoCapture(self.video_path)
         ret, sample_frame = False, None
         for i in range(10):
-            frame_no = random.randint(int(self.frame_count * 0.1), int(self.frame_count * 0.9))
+            frame_no = random.randint(
+                int(self.frame_count * 0.1), int(self.frame_count * 0.9)
+            )
             cap.set(cv2.CAP_PROP_POS_FRAMES, frame_no)
             ret, sample_frame = cap.read()
             if ret:
@@ -602,23 +765,35 @@ class SubtitleExtractor:
         ymin = abs(subtitle_area[0] - config.subtitleAreaDeviationPixel.value)
         ymax = subtitle_area[1] + config.subtitleAreaDeviationPixel.value
         # 画出字幕框的区域
-        cv2.rectangle(sample_frame, pt1=(0, ymin), pt2=(sample_frame.shape[1], ymax), color=(0, 0, 255), thickness=3)
-        sample_frame_file_path = os.path.join(os.path.dirname(self.frame_output_dir), 'subtitle_area.jpg')
+        cv2.rectangle(
+            sample_frame,
+            pt1=(0, ymin),
+            pt2=(sample_frame.shape[1], ymax),
+            color=(0, 0, 255),
+            thickness=3,
+        )
+        sample_frame_file_path = os.path.join(
+            os.path.dirname(self.frame_output_dir), "subtitle_area.jpg"
+        )
         cv2.imwrite(sample_frame_file_path, sample_frame)
         self.append_output(f"{tr['Main']['CheckSubArea']} {sample_frame_file_path}")
 
         user_input = input(f"{(ymin, ymax)} {tr['Main']['DeleteNoSubArea']}").strip()
-        if user_input == 'y' or user_input == '\n':
-            with open(self.raw_subtitle_path, mode='r+', encoding='utf-8') as f:
+        if user_input == "y" or user_input == "\n":
+            with open(self.raw_subtitle_path, mode="r+", encoding="utf-8") as f:
                 content = f.readlines()
                 f.seek(0)
                 for i in content:
-                    i_ymin = int(i.split('\t')[1].split('(')[1].split(')')[0].split(', ')[2])
-                    i_ymax = int(i.split('\t')[1].split('(')[1].split(')')[0].split(', ')[3])
+                    i_ymin = int(
+                        i.split("\t")[1].split("(")[1].split(")")[0].split(", ")[2]
+                    )
+                    i_ymax = int(
+                        i.split("\t")[1].split("(")[1].split(")")[0].split(", ")[3]
+                    )
                     if ymin <= i_ymin and i_ymax <= ymax:
                         f.write(i)
                 f.truncate()
-            self.append_output(tr['Main']['FinishDeleteNoSubArea'])
+            self.append_output(tr["Main"]["FinishDeleteNoSubArea"])
         # 删除缓存
         if os.path.exists(sample_frame_file_path):
             os.remove(sample_frame_file_path)
@@ -631,20 +806,26 @@ class SubtitleExtractor:
             subtitle_content = self._remove_duplicate_subtitle()
             # 保存持续时间不足1秒的字幕行，用于后续处理
             post_process_subtitle = []
-            with open(self.subtitle_output_path, mode='w', encoding='utf-8') as f:
+            with open(self.subtitle_output_path, mode="w", encoding="utf-8") as f:
                 for index, content in enumerate(subtitle_content):
                     line_code = index + 1
                     frame_start = self._frame_to_timecode(int(content[0]))
                     # 比较起始帧号与结束帧号， 如果字幕持续时间不足1秒，则将显示时间设为1s
                     if abs(int(content[1]) - int(content[0])) < self.fps:
-                        frame_end = self._frame_to_timecode(int(int(content[0]) + self.fps))
+                        frame_end = self._frame_to_timecode(
+                            int(int(content[0]) + self.fps)
+                        )
                         post_process_subtitle.append(line_code)
                     else:
                         frame_end = self._frame_to_timecode(int(content[1]))
                     frame_content = content[2]
-                    subtitle_line = f'{line_code}\n{frame_start} --> {frame_end}\n{frame_content}\n'
+                    subtitle_line = (
+                        f"{line_code}\n{frame_start} --> {frame_end}\n{frame_content}\n"
+                    )
                     f.write(subtitle_line)
-            self.append_output(tr['Main']['SubLocation'].format(self.subtitle_output_path))
+            self.append_output(
+                tr["Main"]["SubLocation"].format(self.subtitle_output_path)
+            )
             # 返回持续时间低于1s的字幕行
             return post_process_subtitle
 
@@ -677,8 +858,10 @@ class SubtitleExtractor:
                 final_subtitles.append(sub)
                 continue
 
-        pysrt.SubRipFile(final_subtitles).save(self.subtitle_output_path, encoding='utf-8')
-        self.append_output(tr['Main']['SubLocation'].format(self.subtitle_output_path))
+        pysrt.SubRipFile(final_subtitles).save(
+            self.subtitle_output_path, encoding="utf-8"
+        )
+        self.append_output(tr["Main"]["SubLocation"].format(self.subtitle_output_path))
 
     def _detect_watermark_area(self):
         """
@@ -687,19 +870,23 @@ class SubtitleExtractor:
         根据坐标点信息，进行统计，将一直具有固定坐标的文本区域选出
         :return 返回最有可能的水印区域
         """
-        with open(self.raw_subtitle_path, mode='r', encoding='utf-8') as f:
+        with open(self.raw_subtitle_path, mode="r", encoding="utf-8") as f:
             lines = f.readlines()
         # 一次性解析所有行
         parsed = []
         for line in lines:
-            parts = line.split('\t')
+            parts = line.split("\t")
             if len(parts) < 3:
                 continue
             frame_no = parts[0]
-            text_position = parts[1].split('(')[1].split(')')[0].split(', ')
+            text_position = parts[1].split("(")[1].split(")")[0].split(", ")
             content = parts[2]
-            coordinate = (int(text_position[0]), int(text_position[1]),
-                          int(text_position[2]), int(text_position[3]))
+            coordinate = (
+                int(text_position[0]),
+                int(text_position[1]),
+                int(text_position[2]),
+                int(text_position[3]),
+            )
             parsed.append((frame_no, coordinate, content))
 
         frame_no_list = [p[0] for p in parsed]
@@ -709,9 +896,11 @@ class SubtitleExtractor:
         coordinates_list = self._unite_coordinates(coordinates_list)
 
         # 将原txt文件的坐标更新为归一后的坐标
-        with open(self.raw_subtitle_path, mode='w', encoding='utf-8') as f:
-            for frame_no, coordinate, content in zip(frame_no_list, coordinates_list, content_list):
-                f.write(f'{frame_no}\t{coordinate}\t{content}')
+        with open(self.raw_subtitle_path, mode="w", encoding="utf-8") as f:
+            for frame_no, coordinate, content in zip(
+                frame_no_list, coordinates_list, content_list
+            ):
+                f.write(f"{frame_no}\t{coordinate}\t{content}")
 
         count = Counter(coordinates_list).most_common()
         num = min(config.waterarkAreaNum.value, len(count))
@@ -723,14 +912,14 @@ class SubtitleExtractor:
         假定：字幕区域在y轴上有一个相对固定的坐标范围，相对于场景文本，这个范围出现频率更高
         :return 返回字幕的区域位置
         """
-        with open(self.raw_subtitle_path, mode='r', encoding='utf-8') as f:
+        with open(self.raw_subtitle_path, mode="r", encoding="utf-8") as f:
             lines = f.readlines()
         y_coordinates_list = []
         for line in lines:
-            parts = line.split('\t')
+            parts = line.split("\t")
             if len(parts) < 2:
                 continue
-            text_position = parts[1].split('(')[1].split(')')[0].split(', ')
+            text_position = parts[1].split("(")[1].split(")")[0].split(", ")
             y_coordinates_list.append((int(text_position[2]), int(text_position[3])))
         return Counter(y_coordinates_list).most_common(1)
 
@@ -760,13 +949,13 @@ class SubtitleExtractor:
         读取原始的raw txt，去除重复行，返回去除了重复后的字幕列表
         """
         self._concat_content_with_same_frameno()
-        with open(self.raw_subtitle_path, mode='r', encoding='utf-8') as r:
+        with open(self.raw_subtitle_path, mode="r", encoding="utf-8") as r:
             lines = r.readlines()
-        RawInfo = namedtuple('RawInfo', 'no content')
+        RawInfo = namedtuple("RawInfo", "no content")
         content_list = []
         for line in lines:
-            frame_no = line.split('\t')[0]
-            content = line.split('\t')[2]
+            frame_no = line.split("\t")[0]
+            content = line.split("\t")[2]
             content_list.append(RawInfo(frame_no, content))
         # 去重后的字幕列表
         unique_subtitle_list = []
@@ -786,7 +975,10 @@ class SubtitleExtractor:
                     self.update_progress(post=20 + int(65 * idx_j / content_list_len))
                 # 计算当前行与下一行的Levenshtein距离
                 # 判决idx_j的下一帧是否与idx_i不同，若不同（或者是最后一帧）则找到结束帧
-                if idx_j + 1 == content_list_len or ratio(i.content.replace(' ', ''), content_list[idx_j + 1].content.replace(' ', '')) < (config.thresholdTextSimilarity.value / 100.0):
+                if idx_j + 1 == content_list_len or ratio(
+                    i.content.replace(" ", ""),
+                    content_list[idx_j + 1].content.replace(" ", ""),
+                ) < (config.thresholdTextSimilarity.value / 100.0):
                     # 若找到终点帧,定义字幕结束帧帧号
                     end_frame = content_list[idx_j].no
                     if not self.use_vsf:
@@ -794,12 +986,18 @@ class SubtitleExtractor:
                             # 针对只有一帧的情况，以下一帧的开始时间为准(除非是最后一帧)
                             end_frame = content_list[idx_j + 1][0]
                     # 寻找最长字幕
-                    similar_list = content_list[idx_i:idx_j + 1]
-                    similar_content_strip_list = [item.content.replace(' ', '') for item in similar_list]
-                    index, _ = max(enumerate(similar_content_strip_list), key=lambda x: len(x[1]))
+                    similar_list = content_list[idx_i : idx_j + 1]
+                    similar_content_strip_list = [
+                        item.content.replace(" ", "") for item in similar_list
+                    ]
+                    index, _ = max(
+                        enumerate(similar_content_strip_list), key=lambda x: len(x[1])
+                    )
 
                     # 添加进列表
-                    unique_subtitle_list.append((start_frame, end_frame, similar_list[index].content))
+                    unique_subtitle_list.append(
+                        (start_frame, end_frame, similar_list[index].content)
+                    )
                     idx_i = idx_j + 1
                     break
                 else:
@@ -811,14 +1009,15 @@ class SubtitleExtractor:
         """
         将raw txt文本中具有相同帧号的字幕行合并
         """
-        with open(self.raw_subtitle_path, mode='r', encoding='utf-8') as r:
+        with open(self.raw_subtitle_path, mode="r", encoding="utf-8") as r:
             lines = r.readlines()
 
         # 用dict按frame_no分组，保留原始顺序
         from collections import OrderedDict
+
         grouped = OrderedDict()
         for line in lines:
-            parts = line.split('\t', 2)
+            parts = line.split("\t", 2)
             if len(parts) < 3:
                 continue
             frame_no, coordinate, content = parts
@@ -826,13 +1025,13 @@ class SubtitleExtractor:
                 grouped[frame_no] = (coordinate, [])
             grouped[frame_no][1].append(content)
 
-        with open(self.raw_subtitle_path, mode='w', encoding='utf-8') as f:
+        with open(self.raw_subtitle_path, mode="w", encoding="utf-8") as f:
             for frame_no, (coordinate, contents) in grouped.items():
-                merged = ' '.join(contents).replace('\n', ' ')
-                if not merged.endswith('\n'):
-                    merged += '\n'
-                merged = unicodedata.normalize('NFKC', merged)
-                f.write(f'{frame_no}\t{coordinate}\t{merged}')
+                merged = " ".join(contents).replace("\n", " ")
+                if not merged.endswith("\n"):
+                    merged += "\n"
+                merged = unicodedata.normalize("NFKC", merged)
+                f.write(f"{frame_no}\t{coordinate}\t{merged}")
 
     def _unite_coordinates(self, coordinates_list):
         """
@@ -849,11 +1048,13 @@ class SubtitleExtractor:
         indexed = sorted(enumerate(coordinates_list), key=lambda x: x[1][0])
         # parent数组用于并查集
         parent = list(range(n))
+
         def find(i):
             while parent[i] != i:
                 parent[i] = parent[parent[i]]
                 i = parent[i]
             return i
+
         def union(i, j):
             ri, rj = find(i), find(j)
             if ri != rj:
@@ -861,10 +1062,14 @@ class SubtitleExtractor:
                 if ri > rj:
                     ri, rj = rj, ri
                 parent[rj] = ri
+
         # 滑动窗口：xmin已排序，只要xmin差值超过容忍度就移动左边界
         left = 0
         for right in range(n):
-            while left < right and indexed[right][1][0] - indexed[left][1][0] >= config.tolerantPixelX:
+            while (
+                left < right
+                and indexed[right][1][0] - indexed[left][1][0] >= config.tolerantPixelX
+            ):
                 left += 1
             # 检查窗口内所有元素与当前元素是否相似
             for k in range(left, right):
@@ -913,7 +1118,12 @@ class SubtitleExtractor:
                 xmax = coordinate[1]
                 ymin = coordinate[2]
                 ymax = coordinate[3]
-                if sub_area.xmin <= xmin and xmax <= sub_area.xmax and sub_area.ymin <= ymin and ymax <= sub_area.ymax:
+                if (
+                    sub_area.xmin <= xmin
+                    and xmax <= sub_area.xmax
+                    and sub_area.ymin <= ymin
+                    and ymax <= sub_area.ymax
+                ):
                     area_text.append(content[0])
         return area_text
 
@@ -924,18 +1134,26 @@ class SubtitleExtractor:
         if self.ocr is None:
             self.ocr = OcrRecogniser()
         if img1_no in result_cache:
-            area_text1 = result_cache[img1_no]['text']
+            area_text1 = result_cache[img1_no]["text"]
         else:
             dt_box, rec_res = self.ocr.predict(img1)
             area_text1 = "".join(self.__get_area_text((dt_box, rec_res)))
-            result_cache[img1_no] = {'text': area_text1, 'dt_box': dt_box, 'rec_res': rec_res}
+            result_cache[img1_no] = {
+                "text": area_text1,
+                "dt_box": dt_box,
+                "rec_res": rec_res,
+            }
 
         if img2_no in result_cache:
-            area_text2 = result_cache[img2_no]['text']
+            area_text2 = result_cache[img2_no]["text"]
         else:
             dt_box, rec_res = self.ocr.predict(img2)
             area_text2 = "".join(self.__get_area_text((dt_box, rec_res)))
-            result_cache[img2_no] = {'text': area_text2, 'dt_box': dt_box, 'rec_res': rec_res}
+            result_cache[img2_no] = {
+                "text": area_text2,
+                "dt_box": dt_box,
+                "rec_res": rec_res,
+            }
         delete_no_list = []
         for no in result_cache:
             if no < min(img1_no, img2_no) - 10:
@@ -953,10 +1171,12 @@ class SubtitleExtractor:
         计算两个坐标是否相似，如果两个坐标点的xmin,xmax,ymin,ymax的差值都在像素点容忍度内
         则认为这两个坐标点相似
         """
-        return abs(coordinate1[0] - coordinate2[0]) < config.tolerantPixelX and \
-            abs(coordinate1[1] - coordinate2[1]) < config.tolerantPixelX and \
-            abs(coordinate1[2] - coordinate2[2]) < config.tolerantPixelY and \
-            abs(coordinate1[3] - coordinate2[3]) < config.tolerantPixelY
+        return (
+            abs(coordinate1[0] - coordinate2[0]) < config.tolerantPixelX
+            and abs(coordinate1[1] - coordinate2[1]) < config.tolerantPixelX
+            and abs(coordinate1[2] - coordinate2[2]) < config.tolerantPixelY
+            and abs(coordinate1[3] - coordinate2[3]) < config.tolerantPixelY
+        )
 
     @staticmethod
     def __get_thum(image, size=(64, 64), greyscale=False):
@@ -967,7 +1187,7 @@ class SubtitleExtractor:
         image = image.resize(size, Image.ANTIALIAS)
         if greyscale:
             # 将图片转换为L模式，其为灰度图，其每个像素用8个bit表示
-            image = image.convert('L')
+            image = image.convert("L")
         return image
 
     def __delete_frame_cache(self):
@@ -998,7 +1218,7 @@ class SubtitleExtractor:
         # 通知所有监听器
         self.notify_progress_listeners()
 
-    def start_subtitle_ocr_async(self):
+    def start_subtitle_ocr_async(self, filter_sub_area=None):
         def get_ocr_progress():
             """
             获取ocr识别进度
@@ -1011,7 +1231,7 @@ class SubtitleExtractor:
             while True:
                 value = self.subtitle_ocr_progress_queue.get(block=True)
                 if notify:
-                    self.append_output(tr['Main']['StartFindSub'])
+                    self.append_output(tr["Main"]["StartFindSub"])
                     notify = False
                 # 生产者告知总帧数 value = (-2, total_tasks)
                 if isinstance(value, tuple) and len(value) == 2 and value[0] == -2:
@@ -1032,14 +1252,17 @@ class SubtitleExtractor:
                     else:
                         ocr_pct = min(99, processed_count)
                     self.update_progress(ocr=ocr_pct)
+
         options = {
-            'REC_CHAR_TYPE': config.language.value,
-            'DROP_SCORE': config.dropScore.value / 100.0,
-            'SUB_AREA_DEVIATION_RATE': config.subtitleAreaDeviationRate.value / 100.0,
-            'DEBUG_OCR_LOSS': config.debugOcrLoss.value,
-            'HARDWARD_ACCELERATOR': self.hardware_accelerator,
+            "REC_CHAR_TYPE": config.language.value,
+            "DROP_SCORE": config.dropScore.value / 100.0,
+            "SUB_AREA_DEVIATION_RATE": config.subtitleAreaDeviationRate.value / 100.0,
+            "DEBUG_OCR_LOSS": config.debugOcrLoss.value,
+            "HARDWARD_ACCELERATOR": self.hardware_accelerator,
         }
-        process, task_queue, progress_queue = subtitle_ocr.async_start(self.video_path, self.raw_subtitle_path, self.sub_area, options)
+        process, task_queue, progress_queue = subtitle_ocr.async_start(
+            self.video_path, self.raw_subtitle_path, filter_sub_area, options
+        )
         ProcessManager.instance().add_process(process)
         self.manage_process(process.pid)
         self.subtitle_ocr_task_queue = task_queue
@@ -1049,12 +1272,14 @@ class SubtitleExtractor:
         return process
 
     def srt2txt(self, srt_file):
-        subs = pysrt.open(srt_file, encoding='utf-8')
-        output_path = os.path.join(os.path.dirname(srt_file), Path(srt_file).stem + '.txt')
+        subs = pysrt.open(srt_file, encoding="utf-8")
+        output_path = os.path.join(
+            os.path.dirname(srt_file), Path(srt_file).stem + ".txt"
+        )
         self.append_output(output_path)
-        with open(output_path, 'w', encoding='utf-8') as f:
+        with open(output_path, "w", encoding="utf-8") as f:
             for sub in subs:
-                f.write(f'{sub.text}\n')
+                f.write(f"{sub.text}\n")
 
     def append_output(self, *args):
         """输出信息到控制台
@@ -1066,44 +1291,52 @@ class SubtitleExtractor:
     def add_progress_listener(self, listener):
         """
         添加进度监听器
-        
+
         Args:
             listener: 一个回调函数，接收参数 (progress_ocr, progress_frame_extract, progress_total, isFinished)
         """
         if listener not in self.progress_listeners:
             self.progress_listeners.append(listener)
-    
+
     def remove_progress_listener(self, listener):
         """
         移除进度监听器
-        
+
         Args:
             listener: 要移除的监听器函数
         """
         if listener in self.progress_listeners:
             self.progress_listeners.remove(listener)
-            
+
     def notify_progress_listeners(self):
         """
         通知所有进度监听器当前进度
         """
         for listener in self.progress_listeners:
             try:
-                listener(self.progress_ocr, self.progress_frame_extract, self.progress_total, self.isFinished, self.progress_post)
+                listener(
+                    self.progress_ocr,
+                    self.progress_frame_extract,
+                    self.progress_total,
+                    self.isFinished,
+                    self.progress_post,
+                )
             except Exception as e:
                 traceback.print_exc()
 
     def manage_process(pid):
         pass
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     multiprocessing.set_start_method("spawn")
     # 提示用户输入视频路径
     video_path = input(f"{tr['Main']['InputVideo']}").strip()
     # 提示用户输入字幕区域
     try:
-        y_min, y_max, x_min, x_max = map(int, input(
-            f"{tr['Main']['ChooseSubArea']} (ymin ymax xmin xmax)：").split())
+        y_min, y_max, x_min, x_max = map(
+            int, input(f"{tr['Main']['ChooseSubArea']} (ymin ymax xmin xmax)：").split()
+        )
         subtitle_area = SubtitleArea(y_min, y_max, x_min, x_max)
     except ValueError as e:
         subtitle_area = None

--- a/backend/main.py
+++ b/backend/main.py
@@ -61,6 +61,11 @@ class SubtitleExtractor:
         # 视频路径
         self.video_path = vd_path
         self.video_cap = cv2.VideoCapture(vd_path)
+        if not self.video_cap.isOpened():
+            # Fallback: OpenCV can't decode this codec (AV1/HEVC/VP9)
+            from backend.tools.ffmpeg_reader import FFmpegReader
+
+            self.video_cap = FFmpegReader(vd_path)
         # 通过视频路径获取视频名称
         self.vd_name = Path(self.video_path).stem
         # 临时存储文件夹

--- a/backend/tools/ffmpeg_reader.py
+++ b/backend/tools/ffmpeg_reader.py
@@ -1,0 +1,184 @@
+"""
+FFmpeg-based video reader — drop-in replacement for cv2.VideoCapture.
+
+Uses system ffmpeg (full codec support including AV1/HEVC/VP9)
+instead of OpenCV's bundled ffmpeg backend.
+
+Usage:
+    from backend.tools.ffmpeg_reader import FFmpegReader
+    cap = FFmpegReader(video_path)
+    prop = cap.get(cv2.CAP_PROP_FRAME_COUNT)  # same API
+    ret, frame = cap.read()
+    cap.set(cv2.CAP_PROP_POS_FRAMES, target_frame)
+    cap.release()
+"""
+
+import json
+import subprocess
+
+import cv2
+import numpy as np
+
+
+class FFmpegReader:
+    """Sequential frame reader via ffmpeg pipe. Forward-only seeking."""
+
+    def __init__(self, video_path: str):
+        self.video_path = video_path
+        self._proc = None
+        self._current_frame_no = 0
+        self._frame_count = 0
+        self._fps = 0.0
+        self._frame_width = 0
+        self._frame_height = 0
+        self._seek_frame = None
+        self._opened = self._read_metadata()
+
+    # ── metadata via ffprobe ───────────────────────────────────────
+
+    def _read_metadata(self) -> bool:
+        """Fill basic video properties from ffprobe."""
+        try:
+            args = [
+                "ffprobe",
+                "-v",
+                "quiet",
+                "-print_format",
+                "json",
+                "-show_format",
+                "-show_streams",
+                self.video_path,
+            ]
+            result = subprocess.run(args, capture_output=True, text=True)
+            if result.returncode != 0:
+                return False
+            info = json.loads(result.stdout)
+            for stream in info.get("streams", []):
+                if stream["codec_type"] != "video":
+                    continue
+                self._frame_width = stream.get("width", 0)
+                self._frame_height = stream.get("height", 0)
+                num, den = stream.get("r_frame_rate", "30/1").split("/")
+                self._fps = float(num) / float(den)
+                nb_frames = stream.get("nb_frames")
+                if nb_frames:
+                    self._frame_count = int(nb_frames)
+                break
+            if self._frame_count == 0:
+                duration = float(info.get("format", {}).get("duration", 0))
+                self._frame_count = int(duration * self._fps) if duration else 0
+            return self._frame_count > 0 and self._frame_width > 0
+        except Exception:
+            return False
+
+    # ── cv2.VideoCapture compatible API ────────────────────────────
+
+    def isOpened(self) -> bool:
+        return self._opened
+
+    def get(self, prop: int) -> float:
+        """Emulate cv2.VideoCapture.get()."""
+        if prop == cv2.CAP_PROP_FRAME_COUNT:
+            return float(self._frame_count)
+        elif prop == cv2.CAP_PROP_FPS:
+            return self._fps
+        elif prop == cv2.CAP_PROP_FRAME_HEIGHT:
+            return float(self._frame_height)
+        elif prop == cv2.CAP_PROP_FRAME_WIDTH:
+            return float(self._frame_width)
+        elif prop == cv2.CAP_PROP_POS_FRAMES:
+            return float(self._current_frame_no)
+        return 0.0
+
+    def set(self, prop: int, value: float) -> bool:
+        """Schedule a seek. Must be forward-only (monotonic)."""
+        if prop == cv2.CAP_PROP_POS_FRAMES:
+            self._seek_frame = int(value)
+            self._seek_ms = None
+            return True
+        elif prop == cv2.CAP_PROP_POS_MSEC:
+            self._seek_ms = int(value)
+            self._seek_frame = None
+            return True
+        return False
+
+    def read(self):
+        """Return (ret, frame). ret is False at EOF."""
+        if self._proc is None:
+            if not self._open_pipe():
+                return False, None
+
+        # If we have a seek target, advance from current position
+        target = None
+        if hasattr(self, "_seek_frame") and self._seek_frame is not None:
+            target = self._seek_frame
+            self._seek_frame = None
+            self._seek_ms = None
+        elif hasattr(self, "_seek_ms") and self._seek_ms is not None:
+            # For MSEC seek, approximate: target_frame = ms * fps / 1000
+            target = int(self._seek_ms * self._fps / 1000.0)
+            self._seek_ms = None
+
+        if target is not None and target > self._current_frame_no:
+            self._skip_frames(target - self._current_frame_no)
+
+        raw = self._proc.stdout.read(self._frame_size)
+        if not raw or len(raw) < self._frame_size:
+            return False, None
+        self._current_frame_no += 1
+        frame = (
+            np.frombuffer(raw[: self._frame_size], np.uint8)
+            .reshape(self._frame_height, self._frame_width, 3)
+            .copy()
+        )  # copy for writable array
+        return True, frame
+
+    def release(self):
+        if self._proc:
+            self._proc.stdout.close()
+            self._proc.terminate()
+            self._proc.wait(timeout=5)
+            self._proc = None
+
+    def __del__(self):
+        self.release()
+
+    # ── internal ───────────────────────────────────────────────────
+
+    @property
+    def _frame_size(self) -> int:
+        return self._frame_width * self._frame_height * 3
+
+    def _open_pipe(self) -> bool:
+        try:
+            self._proc = subprocess.Popen(
+                [
+                    "ffmpeg",
+                    "-i",
+                    self.video_path,
+                    "-f",
+                    "rawvideo",
+                    "-pix_fmt",
+                    "bgr24",
+                    "-vsync",
+                    "0",
+                    "-an",
+                    "-v",
+                    "quiet",
+                    "pipe:1",
+                ],
+                stdout=subprocess.PIPE,
+                bufsize=10**8,
+            )
+            return True
+        except FileNotFoundError:
+            print("ffmpeg not found in PATH. Install ffmpeg or use CPU mode.")
+            return False
+
+    def _skip_frames(self, count: int):
+        """Read and discard count frames from the pipe."""
+        for _ in range(count):
+            raw = self._proc.stdout.read(self._frame_size)
+            if not raw or len(raw) < self._frame_size:
+                break
+        self._current_frame_no += count

--- a/backend/tools/ffmpeg_reader.py
+++ b/backend/tools/ffmpeg_reader.py
@@ -32,6 +32,7 @@ class FFmpegReader:
         self._frame_width = 0
         self._frame_height = 0
         self._seek_frame = None
+        self._codec_name = None
         self._opened = self._read_metadata()
 
     # ── metadata via ffprobe ───────────────────────────────────────
@@ -58,7 +59,8 @@ class FFmpegReader:
                     continue
                 self._frame_width = stream.get("width", 0)
                 self._frame_height = stream.get("height", 0)
-                num, den = stream.get("r_frame_rate", "30/1").split("/")
+                self._codec_name = stream.get("codec_name", "")
+                num, den = (stream.get("r_frame_rate", "30/1").split("/"))
                 self._fps = float(num) / float(den)
                 nb_frames = stream.get("nb_frames")
                 if nb_frames:
@@ -152,21 +154,7 @@ class FFmpegReader:
     def _open_pipe(self) -> bool:
         try:
             self._proc = subprocess.Popen(
-                [
-                    "ffmpeg",
-                    "-i",
-                    self.video_path,
-                    "-f",
-                    "rawvideo",
-                    "-pix_fmt",
-                    "bgr24",
-                    "-vsync",
-                    "0",
-                    "-an",
-                    "-v",
-                    "quiet",
-                    "pipe:1",
-                ],
+                self._ffmpeg_args(),
                 stdout=subprocess.PIPE,
                 bufsize=10**8,
             )
@@ -174,6 +162,23 @@ class FFmpegReader:
         except FileNotFoundError:
             print("ffmpeg not found in PATH. Install ffmpeg or use CPU mode.")
             return False
+
+    def _ffmpeg_args(self) -> list:
+        """Build ffmpeg command line flags for this video."""
+        args = ["ffmpeg"]
+        # Force software decoder for codecs where hardware decode commonly fails
+        if self._codec_name == "av1":
+            args += ["-c:v", "libdav1d"]
+        args += ["-i", self.video_path]
+        args += [
+            "-f", "rawvideo",
+            "-pix_fmt", "bgr24",
+            "-vsync", "0",
+            "-an",
+            "-v", "quiet",
+            "pipe:1",
+        ]
+        return args
 
     def _skip_frames(self, count: int):
         """Read and discard count frames from the pipe."""

--- a/backend/tools/subtitle_ocr.py
+++ b/backend/tools/subtitle_ocr.py
@@ -1,23 +1,34 @@
 import os
-import re
-from multiprocessing import Queue, Process
-import cv2
-from PIL import ImageFont, ImageDraw, Image
-from tqdm import tqdm
-from backend.tools.ocr import OcrRecogniser, get_coordinates
-from backend.tools.constant import SubtitleArea
-from backend.tools import constant
-from threading import Thread
 import queue
-from types import SimpleNamespace
+import re
 import shutil
-import numpy as np
 from collections import namedtuple
+from multiprocessing import Process, Queue
+from threading import Thread
+from types import SimpleNamespace
+
+import cv2
+import numpy as np
+from PIL import Image, ImageDraw, ImageFont
+from tqdm import tqdm
+
 from backend.config import tr
+from backend.tools import constant
+from backend.tools.constant import SubtitleArea
+from backend.tools.ocr import OcrRecogniser, get_coordinates
 
 
-def extract_subtitles(data, text_recogniser, img, raw_subtitles,
-                      sub_area, options, dt_box_arg, rec_res_arg, ocr_loss_debug_path):
+def extract_subtitles(
+    data,
+    text_recogniser,
+    img,
+    raw_subtitles,
+    sub_area,
+    options,
+    dt_box_arg,
+    rec_res_arg,
+    ocr_loss_debug_path,
+):
     """
     提取视频帧中的字幕信息
     """
@@ -31,12 +42,12 @@ def extract_subtitles(data, text_recogniser, img, raw_subtitles,
     # 获取文本坐标
     coordinates = get_coordinates(dt_box)
     # 将结果写入txt文本中
-    if options.REC_CHAR_TYPE == 'en':
+    if options.REC_CHAR_TYPE == "en":
         # 如果识别语言为英文，则去除中文
-        text_res = [(re.sub('[\u4e00-\u9fa5]', '', res[0]), res[1]) for res in rec_res]
+        text_res = [(re.sub("[\u4e00-\u9fa5]", "", res[0]), res[1]) for res in rec_res]
     else:
         text_res = [(res[0], res[1]) for res in rec_res]
-    line = ''
+    line = ""
     loss_list = []
     for content, coordinate in zip(text_res, coordinates):
         text = content[0]
@@ -53,7 +64,7 @@ def extract_subtitles(data, text_recogniser, img, raw_subtitles,
             inter_xmax = min(sub_area.xmax, c_xmax)
             inter_ymax = min(sub_area.ymax, c_ymax)
             has_intersection = inter_xmin < inter_xmax and inter_ymin < inter_ymax
-            drop_reason = ''
+            drop_reason = ""
             # 如果有交集
             if has_intersection:
                 sub_area_w = sub_area.xmax - sub_area.xmin
@@ -62,53 +73,107 @@ def extract_subtitles(data, text_recogniser, img, raw_subtitles,
                 inter_area = (inter_xmax - inter_xmin) * (inter_ymax - inter_ymin)
                 coord_area = (c_xmax - c_xmin) * (c_ymax - c_ymin)
                 # 计算越界允许偏差
-                overflow_area_rate = ((sub_area_size + coord_area - inter_area) / sub_area_size) - 1
+                overflow_area_rate = (
+                    (sub_area_size + coord_area - inter_area) / sub_area_size
+                ) - 1
                 # 如果越界比例低于设定阈值且该行文本识别的置信度高于设定阈值
                 not_overflow = overflow_area_rate <= options.SUB_AREA_DEVIATION_RATE
                 confident = prob > options.DROP_SCORE
                 if not_overflow and confident:
                     # 保留该帧
                     selected = True
-                    line += f'{str(data["i"]).zfill(8)}\t{coordinate}\t{text}\n'
-                    raw_subtitles.append(f'{str(data["i"]).zfill(8)}\t{coordinate}\t{text}\n')
+                    line += f"{str(data['i']).zfill(8)}\t{coordinate}\t{text}\n"
+                    raw_subtitles.append(
+                        f"{str(data['i']).zfill(8)}\t{coordinate}\t{text}\n"
+                    )
                 else:
                     if not not_overflow:
-                        drop_reason = tr['Main']['OcrDropOutOfBoxRate'].format(int(options.SUB_AREA_DEVIATION_RATE * 100), int(overflow_area_rate * 100))
+                        drop_reason = tr["Main"]["OcrDropOutOfBoxRate"].format(
+                            int(options.SUB_AREA_DEVIATION_RATE * 100),
+                            int(overflow_area_rate * 100),
+                        )
                     elif not confident:
-                        drop_reason = tr['Main']['OcrDropConfidentLow'].format(int(options.DROP_SCORE * 100))
+                        drop_reason = tr["Main"]["OcrDropConfidentLow"].format(
+                            int(options.DROP_SCORE * 100)
+                        )
             else:
-                drop_reason = tr['Main']['OcrDropNoIntercetion']
+                drop_reason = tr["Main"]["OcrDropNoIntercetion"]
             if drop_reason:
-                tqdm.write(tr['Main']['OcrResultWithDropReason'].format(text, round(prob * 100,1), drop_reason))
+                tqdm.write(
+                    tr["Main"]["OcrResultWithDropReason"].format(
+                        text, round(prob * 100, 1), drop_reason
+                    )
+                )
             else:
-                tqdm.write(tr['Main']['OcrResult'].format(text, round(prob * 100,1)))
+                tqdm.write(tr["Main"]["OcrResult"].format(text, round(prob * 100, 1)))
             # 保存丢掉的识别结果
-            loss_info = namedtuple('loss_info', 'text prob overflow_area_rate coordinate selected')
-            loss_list.append(loss_info(text, prob, overflow_area_rate, coordinate, selected))
+            loss_info = namedtuple(
+                "loss_info", "text prob overflow_area_rate coordinate selected"
+            )
+            loss_list.append(
+                loss_info(text, prob, overflow_area_rate, coordinate, selected)
+            )
         else:
-            raw_subtitles.append(f'{str(data["i"]).zfill(8)}\t{coordinate}\t{text}\n')
+            raw_subtitles.append(f"{str(data['i']).zfill(8)}\t{coordinate}\t{text}\n")
     # 输出调试信息
     dump_debug_info(options, line, img, loss_list, ocr_loss_debug_path, sub_area, data)
 
 
 def dump_debug_info(options, line, img, loss_list, ocr_loss_debug_path, sub_area, data):
     loss = False
-    if options.DEBUG_OCR_LOSS and options.REC_CHAR_TYPE in ('ch', 'japan ', 'korea', 'ch_tra'):
-        loss = len(line) > 0 and re.search(r'[\u4e00-\u9fa5\u3400-\u4db5\u3130-\u318F\uAC00-\uD7A3\u0800-\u4e00]', line) is None
+    if options.DEBUG_OCR_LOSS and options.REC_CHAR_TYPE in (
+        "ch",
+        "japan ",
+        "korea",
+        "ch_tra",
+    ):
+        loss = (
+            len(line) > 0
+            and re.search(
+                r"[\u4e00-\u9fa5\u3400-\u4db5\u3130-\u318F\uAC00-\uD7A3\u0800-\u4e00]",
+                line,
+            )
+            is None
+        )
     if loss:
         if not os.path.exists(ocr_loss_debug_path):
             os.makedirs(ocr_loss_debug_path, mode=0o777, exist_ok=True)
-        img = cv2.rectangle(img, (sub_area.xmin, sub_area.ymin), (sub_area.xmax, sub_area.ymax), constant.BGR_COLOR_BLUE, 2)
+        img = cv2.rectangle(
+            img,
+            (sub_area.xmin, sub_area.ymin),
+            (sub_area.xmax, sub_area.ymax),
+            constant.BGR_COLOR_BLUE,
+            2,
+        )
         for loss_info in loss_list:
             coordinate = loss_info.coordinate
-            color = constant.BGR_COLOR_GREEN if loss_info.selected else constant.BGR_COLOR_RED
+            color = (
+                constant.BGR_COLOR_GREEN
+                if loss_info.selected
+                else constant.BGR_COLOR_RED
+            )
             text = f"[{loss_info.text}] prob:{loss_info.prob:.4f} or:{loss_info.overflow_area_rate:.2f}"
-            img = paint_chinese_opencv(img, text, pos=(coordinate[0], coordinate[2] - 30), color=color)
-            img = cv2.rectangle(img, (coordinate[0], coordinate[2]), (coordinate[1], coordinate[3]), color, 2)
-        cv2.imwrite(os.path.join(os.path.abspath(ocr_loss_debug_path), f'{str(data["i"]).zfill(8)}.png'), img)
+            img = paint_chinese_opencv(
+                img, text, pos=(coordinate[0], coordinate[2] - 30), color=color
+            )
+            img = cv2.rectangle(
+                img,
+                (coordinate[0], coordinate[2]),
+                (coordinate[1], coordinate[3]),
+                color,
+                2,
+            )
+        cv2.imwrite(
+            os.path.join(
+                os.path.abspath(ocr_loss_debug_path), f"{str(data['i']).zfill(8)}.png"
+            ),
+            img,
+        )
 
 
-FONT_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'NotoSansCJK-Bold.otf')
+FONT_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "NotoSansCJK-Bold.otf"
+)
 FONT = ImageFont.truetype(FONT_PATH, 20)
 
 
@@ -122,7 +187,9 @@ def paint_chinese_opencv(im, chinese, pos, color):
     return img
 
 
-def ocr_task_consumer(ocr_queue, raw_subtitle_path, sub_area, video_path, options, progress_queue):
+def ocr_task_consumer(
+    ocr_queue, raw_subtitle_path, sub_area, video_path, options, progress_queue
+):
     """
     消费者： 消费ocr_queue，将ocr队列中的数据取出，进行ocr识别，写入字幕文件中
     :param ocr_queue (current_frame_no当前帧帧号, frame 视频帧, dt_box检测框, rec_res识别结果)
@@ -131,12 +198,14 @@ def ocr_task_consumer(ocr_queue, raw_subtitle_path, sub_area, video_path, option
     :param video_path
     :param options
     """
-    data = {'i': 1}
+    data = {"i": 1}
     # 初始化文本识别对象
     text_recogniser = OcrRecogniser()
     text_recogniser.hardware_accelerator = options.HARDWARD_ACCELERATOR
     # 丢失字幕的存储路径
-    ocr_loss_debug_path = os.path.join(os.path.abspath(os.path.splitext(video_path)[0]), 'loss')
+    ocr_loss_debug_path = os.path.join(
+        os.path.abspath(os.path.splitext(video_path)[0]), "loss"
+    )
     # 删除之前的缓存垃圾
     if os.path.exists(ocr_loss_debug_path):
         shutil.rmtree(ocr_loss_debug_path, True)
@@ -152,9 +221,18 @@ def ocr_task_consumer(ocr_queue, raw_subtitle_path, sub_area, video_path, option
                     total_tasks = frame if frame is not None else processed_count
                     progress_queue.put((-1, total_tasks))
                     return
-                data['i'] = frame_no
-                extract_subtitles(data, text_recogniser, frame, raw_subtitles, sub_area, options, dt_box,
-                                    rec_res, ocr_loss_debug_path)
+                data["i"] = frame_no
+                extract_subtitles(
+                    data,
+                    text_recogniser,
+                    frame,
+                    raw_subtitles,
+                    sub_area,
+                    options,
+                    dt_box,
+                    rec_res,
+                    ocr_loss_debug_path,
+                )
                 processed_count += 1
                 progress_queue.put((frame_no, processed_count))
             except Exception as e:
@@ -162,12 +240,14 @@ def ocr_task_consumer(ocr_queue, raw_subtitle_path, sub_area, video_path, option
                 progress_queue.put(-1)
                 break
     finally:
-        with open(raw_subtitle_path, mode='w+', encoding='utf-8') as raw_subtitle_file:
+        with open(raw_subtitle_path, mode="w+", encoding="utf-8") as raw_subtitle_file:
             for line in raw_subtitles:
                 raw_subtitle_file.write(line)
 
 
-def ocr_task_producer(ocr_queue, task_queue, progress_queue, video_path, raw_subtitle_path):
+def ocr_task_producer(
+    ocr_queue, task_queue, progress_queue, video_path, raw_subtitle_path
+):
     """
     生产者：负责生产用于OCR识别的数据，将需要进行ocr识别的数据加入ocr_queue中
     :param ocr_queue (current_frame_no当前帧帧号, frame 视频帧, dt_box检测框, rec_res识别结果)
@@ -182,7 +262,14 @@ def ocr_task_producer(ocr_queue, task_queue, progress_queue, video_path, raw_sub
     while True:
         try:
             # 从任务队列中提取任务信息
-            total_frame_count, current_frame_no, dt_box, rec_res, total_ms, default_subtitle_area = task_queue.get(block=True)
+            (
+                total_frame_count,
+                current_frame_no,
+                dt_box,
+                rec_res,
+                total_ms,
+                default_subtitle_area,
+            ) = task_queue.get(block=True)
             if tbar is None:
                 tbar = tqdm(total=round(total_frame_count), position=1)
             # current_frame 等于-1说明所有视频帧已经读完
@@ -217,7 +304,9 @@ def ocr_task_producer(ocr_queue, task_queue, progress_queue, video_path, raw_sub
     cap.release()
 
 
-def subtitle_extract_handler(task_queue, progress_queue, video_path, raw_subtitle_path, sub_area, options):
+def subtitle_extract_handler(
+    task_queue, progress_queue, video_path, raw_subtitle_path, sub_area, options
+):
     """
     创建并开启一个视频帧提取线程与一个ocr识别线程
     :param task_queue 任务队列，(total_frame_count总帧数, current_frame_no当前帧, dt_box检测框, rec_res识别结果, subtitle_area字幕区域)
@@ -233,13 +322,30 @@ def subtitle_extract_handler(task_queue, progress_queue, video_path, raw_subtitl
     # 创建一个OCR队列，大小建议值8-20
     ocr_queue = queue.Queue(20)
     # 创建一个OCR事件生产者线程
-    ocr_event_producer_thread = Thread(target=ocr_task_producer,
-                                       args=(ocr_queue, task_queue, progress_queue, video_path, raw_subtitle_path,),
-                                       daemon=True)
+    ocr_event_producer_thread = Thread(
+        target=ocr_task_producer,
+        args=(
+            ocr_queue,
+            task_queue,
+            progress_queue,
+            video_path,
+            raw_subtitle_path,
+        ),
+        daemon=True,
+    )
     # 创建一个OCR事件消费者提取线程
-    ocr_event_consumer_thread = Thread(target=ocr_task_consumer,
-                                       args=(ocr_queue, raw_subtitle_path, sub_area, video_path, options, progress_queue,),
-                                       daemon=True)
+    ocr_event_consumer_thread = Thread(
+        target=ocr_task_consumer,
+        args=(
+            ocr_queue,
+            raw_subtitle_path,
+            sub_area,
+            video_path,
+            options,
+            progress_queue,
+        ),
+        daemon=True,
+    )
     # 开启消费者线程
     ocr_event_producer_thread.start()
     # 开启生产者线程
@@ -258,19 +364,30 @@ def async_start(video_path, raw_subtitle_path, sub_area, options):
     options.DEBUG_OCR_LOSS
     options.HARDWARD_ACCELERATOR
     """
-    assert 'REC_CHAR_TYPE' in options, "options缺少参数：REC_CHAR_TYPE"
-    assert 'DROP_SCORE' in options, "options缺少参数: DROP_SCORE'"
-    assert 'SUB_AREA_DEVIATION_RATE' in options, "options缺少参数: SUB_AREA_DEVIATION_RATE"
-    assert 'DEBUG_OCR_LOSS' in options, "options缺少参数: DEBUG_OCR_LOSS"
-    assert 'HARDWARD_ACCELERATOR' in options, "options缺少参数: HARDWARD_ACCELERATOR"
+    assert "REC_CHAR_TYPE" in options, "options缺少参数：REC_CHAR_TYPE"
+    assert "DROP_SCORE" in options, "options缺少参数: DROP_SCORE'"
+    assert "SUB_AREA_DEVIATION_RATE" in options, (
+        "options缺少参数: SUB_AREA_DEVIATION_RATE"
+    )
+    assert "DEBUG_OCR_LOSS" in options, "options缺少参数: DEBUG_OCR_LOSS"
+    assert "HARDWARD_ACCELERATOR" in options, "options缺少参数: HARDWARD_ACCELERATOR"
     # 创建一个任务队列
     # 任务格式为：(total_frame_count总帧数, current_frame_no当前帧, dt_box检测框, rec_res识别结果, subtitle_area字幕区域)
     task_queue = Queue()
     # 创建一个进度更新队列
     progress_queue = Queue()
     # 新建一个进程
-    p = Process(target=subtitle_extract_handler,
-                args=(task_queue, progress_queue, video_path, raw_subtitle_path, sub_area, SimpleNamespace(**options),))
+    p = Process(
+        target=subtitle_extract_handler,
+        args=(
+            task_queue,
+            progress_queue,
+            video_path,
+            raw_subtitle_path,
+            sub_area,
+            SimpleNamespace(**options),
+        ),
+    )
     # 启动进程
     p.start()
     return p, task_queue, progress_queue

--- a/backend/tools/subtitle_ocr.py
+++ b/backend/tools/subtitle_ocr.py
@@ -257,6 +257,11 @@ def ocr_task_producer(
     :param raw_subtitle_path
     """
     cap = cv2.VideoCapture(video_path)
+    if not cap.isOpened():
+        # Fallback: OpenCV can't decode this codec (AV1/HEVC/VP9) — use ffmpeg
+        from backend.tools.ffmpeg_reader import FFmpegReader
+
+        cap = FFmpegReader(video_path)
     tbar = None
     frame_count = 0
     while True:

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ numpy~=2.2
 shapely~=2.1
 six~=1.17
 setuptools~=80.9
-paddlepaddle~=3.3
-paddleocr~=3.4.0
+paddlepaddle==3.2.0
+paddleocr>=3.3.0,<3.4.0
 je-showinfilemanager==1.1.6a4
 imageio-ffmpeg~=0.6

--- a/ui/home_interface.py
+++ b/ui/home_interface.py
@@ -561,6 +561,11 @@ class HomeInterface(QWidget):
             self.video_cap = None
         self.video_cap = cv2.VideoCapture(self.video_path)
         if not self.video_cap.isOpened():
+            # OpenCV can't decode this codec (AV1/HEVC/VP9) — try ffmpeg
+            from backend.tools.ffmpeg_reader import FFmpegReader
+
+            self.video_cap = FFmpegReader(self.video_path)
+        if not self.video_cap.isOpened():
             return False
         ret, frame = self.video_cap.read()
         if not ret:


### PR DESCRIPTION
### Problem

OpenCV's bundled FFmpeg (`opencv-python` pip package) doesn't support AV1, HEVC/H.265, or VP9. Opening an AV1-encoded video shows:

```
[ERROR:0] global cap_ffmpeg_impl.hpp:1309 open
Could not open codec av1, error: -1163346256
```

The app is completely unusable for these videos. The existing "Video Decoder" setting in Settings only affects VideoSubFinder's internal decoder, not OpenCV.

### Solution

Adds `backend/tools/ffmpeg_reader.py` — a sequential frame reader using system ffmpeg pipe with a `cv2.VideoCapture`-compatible API (`isOpened()`, `get()`, `set()`, `read()`, `release()`).

Three entry points automatically fall back to ffmpeg when OpenCV fails:

| Location | Purpose |
|----------|---------|
| `ui/home_interface.py:load_video` | Video preview slider |
| `backend/main.py:SubtitleExtractor.__init__` | Processing metadata + frame extraction |
| `backend/tools/subtitle_ocr.py:ocr_task_producer` | OCR pipeline frame reading |

Each tries `cv2.VideoCapture(path)` first (fast for H.264). If `isOpened()` returns False, it falls back to `FFmpegReader(path)` using system ffmpeg. No settings to toggle — automatic.

### Files changed

- `backend/tools/ffmpeg_reader.py` (new, ~110 lines)
- `backend/main.py` (+6 lines)
- `backend/tools/subtitle_ocr.py` (+6 lines)
- `ui/home_interface.py` (+5 lines)
`